### PR TITLE
Implement persistent categories and automation rules

### DIFF
--- a/app/api/categories/[id]/route.ts
+++ b/app/api/categories/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { deleteCategory, updateCategory } from "@/lib/categories/service"
+
+const updateSchema = z.object({
+  name: z.string().min(1, "Name is required").optional(),
+  icon: z.string().min(1, "Icon is required").optional(),
+  color: z.string().min(1, "Color is required").optional(),
+  monthlyBudget: z.coerce.number().min(0, "Budget must be at least 0").optional(),
+})
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const payload = await request.json()
+    const parsed = updateSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const category = await updateCategory(params.id, parsed.data)
+    return NextResponse.json({ category })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await deleteCategory(params.id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { createCategory, listCategories } from "@/lib/categories/service"
+
+const querySchema = z.object({
+  search: z.string().optional(),
+})
+
+const createSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  icon: z.string().min(1, "Icon is required"),
+  color: z.string().min(1, "Color is required"),
+  monthlyBudget: z.coerce.number().min(0, "Budget must be at least 0"),
+})
+
+type CreateCategoryPayload = z.infer<typeof createSchema>
+
+type QueryParams = z.infer<typeof querySchema>
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url)
+    const params = Object.fromEntries(url.searchParams.entries())
+    const parsed = querySchema.safeParse(params)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const categories = await listCategories(parsed.data as QueryParams)
+    return NextResponse.json({ categories })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await request.json()
+    const parsed = createSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const category = await createCategory(parsed.data as CreateCategoryPayload)
+    return NextResponse.json({ category }, { status: 201 })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/categories/rules/[id]/route.ts
+++ b/app/api/categories/rules/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { deleteAutomationRule, updateAutomationRule } from "@/lib/categories/service"
+
+const updateSchema = z.object({
+  name: z.string().min(1, "Name is required").optional(),
+  categoryId: z.string().min(1, "Category is required").optional(),
+  type: z.enum(["contains", "starts_with", "ends_with", "exact", "regex"]).optional(),
+  pattern: z.string().min(1, "Pattern is required").optional(),
+  priority: z.coerce.number().int().min(1, "Priority must be at least 1").optional(),
+  isActive: z.boolean().optional(),
+  description: z.string().optional(),
+})
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const payload = await request.json()
+    const parsed = updateSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const rule = await updateAutomationRule(params.id, parsed.data)
+    return NextResponse.json({ rule })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await deleteAutomationRule(params.id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/categories/rules/route.ts
+++ b/app/api/categories/rules/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { createAutomationRule, listAutomationRules } from "@/lib/categories/service"
+
+const querySchema = z.object({
+  search: z.string().optional(),
+})
+
+const createSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  categoryId: z.string().min(1, "Category is required"),
+  type: z.enum(["contains", "starts_with", "ends_with", "exact", "regex"]),
+  pattern: z.string().min(1, "Pattern is required"),
+  priority: z.coerce.number().int().min(1, "Priority must be at least 1"),
+  isActive: z.boolean(),
+  description: z.string().optional(),
+})
+
+type QueryParams = z.infer<typeof querySchema>
+
+type CreateRulePayload = z.infer<typeof createSchema>
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url)
+    const params = Object.fromEntries(url.searchParams.entries())
+    const parsed = querySchema.safeParse(params)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const rules = await listAutomationRules(parsed.data as QueryParams)
+    return NextResponse.json(rules)
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await request.json()
+    const parsed = createSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const rule = await createAutomationRule(parsed.data as CreateRulePayload)
+    return NextResponse.json({ rule }, { status: 201 })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/components/add-rule-dialog.tsx
+++ b/components/add-rule-dialog.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import type React from "react"
-
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -18,90 +16,136 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea"
 import { Switch } from "@/components/ui/switch"
 
-interface AddRuleDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+export interface RuleFormValues {
+  name: string
+  categoryId: string
+  type: "contains" | "starts_with" | "ends_with" | "exact" | "regex"
+  pattern: string
+  priority: string
+  isActive: boolean
+  description: string
 }
 
-const categories = [
-  "Food & Dining",
-  "Transportation",
-  "Entertainment",
-  "Shopping",
-  "Bills & Utilities",
-  "Healthcare",
-  "Education",
-  "Income",
-]
+interface CategoryOption {
+  id: string
+  name: string
+}
 
-export function AddRuleDialog({ open, onOpenChange }: AddRuleDialogProps) {
-  const [formData, setFormData] = useState({
-    name: "",
-    category: "",
-    type: "contains",
-    pattern: "",
-    priority: "1",
-    isActive: true,
-    description: "",
-  })
+interface AddRuleDialogProps {
+  open: boolean
+  mode: "create" | "edit"
+  onOpenChange: (open: boolean) => void
+  onSubmit: (values: RuleFormValues) => Promise<void>
+  categories: CategoryOption[]
+  initialValues?: RuleFormValues
+}
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    console.log("Rule data:", formData)
-    onOpenChange(false)
-    setFormData({
-      name: "",
-      category: "",
-      type: "contains",
-      pattern: "",
-      priority: "1",
-      isActive: true,
-      description: "",
-    })
+const createDefaultValues = (categories: CategoryOption[]): RuleFormValues => ({
+  name: "",
+  categoryId: categories[0]?.id ?? "",
+  type: "contains",
+  pattern: "",
+  priority: "1",
+  isActive: true,
+  description: "",
+})
+
+export function AddRuleDialog({ open, mode, onOpenChange, onSubmit, categories, initialValues }: AddRuleDialogProps) {
+  const [formData, setFormData] = useState<RuleFormValues>(() => createDefaultValues(categories))
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const categoryOptions = useMemo(() => categories.map((category) => ({ id: category.id, name: category.name })), [categories])
+
+  useEffect(() => {
+    if (open) {
+      setError(null)
+      setIsSubmitting(false)
+      if (initialValues) {
+        setFormData(initialValues)
+      } else {
+        setFormData(createDefaultValues(categories))
+      }
+    }
+  }, [open, categories, initialValues])
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      if (!formData.name.trim()) {
+        throw new Error("Rule name is required")
+      }
+      if (!formData.categoryId) {
+        throw new Error("Please select a category")
+      }
+      if (!formData.pattern.trim()) {
+        throw new Error("Pattern is required")
+      }
+
+      await onSubmit(formData)
+      if (mode === "create") {
+        setFormData(createDefaultValues(categories))
+      }
+      onOpenChange(false)
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Failed to save rule")
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>Add Automation Rule</DialogTitle>
-          <DialogDescription>Create a rule to automatically categorize transactions</DialogDescription>
+          <DialogTitle>{mode === "create" ? "Add Automation Rule" : "Edit Automation Rule"}</DialogTitle>
+          <DialogDescription>
+            {mode === "create"
+              ? "Create a rule to automatically categorize transactions"
+              : "Update the automation rule configuration"}
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="name">Rule Name</Label>
+            <Label htmlFor="rule-name">Rule Name</Label>
             <Input
-              id="name"
+              id="rule-name"
               placeholder="e.g., Grocery Stores"
               value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              onChange={(event) => setFormData((previous) => ({ ...previous, name: event.target.value }))}
               required
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="category">Category</Label>
+              <Label htmlFor="rule-category">Category</Label>
               <Select
-                value={formData.category}
-                onValueChange={(value) => setFormData({ ...formData, category: value })}
+                value={formData.categoryId}
+                onValueChange={(value) => setFormData((previous) => ({ ...previous, categoryId: value }))}
               >
-                <SelectTrigger>
+                <SelectTrigger id="rule-category">
                   <SelectValue placeholder="Select category" />
                 </SelectTrigger>
                 <SelectContent>
-                  {categories.map((category) => (
-                    <SelectItem key={category} value={category}>
-                      {category}
+                  {categoryOptions.map((category) => (
+                    <SelectItem key={category.id} value={category.id}>
+                      {category.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="type">Match Type</Label>
-              <Select value={formData.type} onValueChange={(value) => setFormData({ ...formData, type: value })}>
-                <SelectTrigger>
+              <Label htmlFor="rule-type">Match Type</Label>
+              <Select
+                value={formData.type}
+                onValueChange={(value: RuleFormValues["type"]) => setFormData((previous) => ({ ...previous, type: value }))}
+              >
+                <SelectTrigger id="rule-type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -116,12 +160,12 @@ export function AddRuleDialog({ open, onOpenChange }: AddRuleDialogProps) {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="pattern">Pattern</Label>
+            <Label htmlFor="rule-pattern">Pattern</Label>
             <Input
-              id="pattern"
+              id="rule-pattern"
               placeholder="e.g., grocery|supermarket|walmart"
               value={formData.pattern}
-              onChange={(e) => setFormData({ ...formData, pattern: e.target.value })}
+              onChange={(event) => setFormData((previous) => ({ ...previous, pattern: event.target.value }))}
               required
             />
             <p className="text-xs text-muted-foreground">
@@ -130,24 +174,24 @@ export function AddRuleDialog({ open, onOpenChange }: AddRuleDialogProps) {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="description">Description (Optional)</Label>
+            <Label htmlFor="rule-description">Description (Optional)</Label>
             <Textarea
-              id="description"
+              id="rule-description"
               placeholder="Describe what this rule matches..."
               value={formData.description}
-              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              onChange={(event) => setFormData((previous) => ({ ...previous, description: event.target.value }))}
               rows={2}
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="priority">Priority</Label>
+              <Label htmlFor="rule-priority">Priority</Label>
               <Select
                 value={formData.priority}
-                onValueChange={(value) => setFormData({ ...formData, priority: value })}
+                onValueChange={(value) => setFormData((previous) => ({ ...previous, priority: value }))}
               >
-                <SelectTrigger>
+                <SelectTrigger id="rule-priority">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -158,25 +202,29 @@ export function AddRuleDialog({ open, onOpenChange }: AddRuleDialogProps) {
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="active">Active</Label>
+              <Label htmlFor="rule-active">Active</Label>
               <div className="flex items-center space-x-2 pt-2">
                 <Switch
-                  id="active"
+                  id="rule-active"
                   checked={formData.isActive}
-                  onCheckedChange={(checked) => setFormData({ ...formData, isActive: checked })}
+                  onCheckedChange={(checked) => setFormData((previous) => ({ ...previous, isActive: checked }))}
                 />
-                <Label htmlFor="active" className="text-sm">
+                <Label htmlFor="rule-active" className="text-sm">
                   {formData.isActive ? "Enabled" : "Disabled"}
                 </Label>
               </div>
             </div>
           </div>
 
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
               Cancel
             </Button>
-            <Button type="submit">Add Rule</Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : mode === "create" ? "Add Rule" : "Save Changes"}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/data/automation-rules.json
+++ b/data/automation-rules.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "rule_groceries",
+    "name": "Grocery Stores",
+    "categoryId": "cat_food",
+    "type": "contains",
+    "pattern": "grocery|supermarket|walmart|target",
+    "priority": 1,
+    "isActive": true,
+    "description": "Matches common grocery merchants",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "rule_gas",
+    "name": "Gas Stations",
+    "categoryId": "cat_transport",
+    "type": "contains",
+    "pattern": "shell|exxon|bp|chevron|gas",
+    "priority": 2,
+    "isActive": true,
+    "description": "Categorize fuel purchases",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "rule_streaming",
+    "name": "Streaming Services",
+    "categoryId": "cat_entertainment",
+    "type": "contains",
+    "pattern": "netflix|spotify|hulu|disney|amazon prime",
+    "priority": 1,
+    "isActive": true,
+    "description": "Automatically tag streaming subscriptions",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "rule_coffee",
+    "name": "Coffee Shops",
+    "categoryId": "cat_food",
+    "type": "contains",
+    "pattern": "starbucks|coffee|cafe",
+    "priority": 3,
+    "isActive": true,
+    "description": "Daily caffeine fix",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "rule_utilities",
+    "name": "Utility Bills",
+    "categoryId": "cat_bills",
+    "type": "contains",
+    "pattern": "electric|water|gas bill|internet|phone bill",
+    "priority": 1,
+    "isActive": true,
+    "description": "Utility service providers",
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  }
+]

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "cat_food",
+    "name": "Food & Dining",
+    "icon": "🍽️",
+    "color": "bg-blue-500",
+    "monthlyBudget": 600,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "cat_transport",
+    "name": "Transportation",
+    "icon": "🚗",
+    "color": "bg-green-500",
+    "monthlyBudget": 300,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "cat_entertainment",
+    "name": "Entertainment",
+    "icon": "🎬",
+    "color": "bg-purple-500",
+    "monthlyBudget": 200,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "cat_shopping",
+    "name": "Shopping",
+    "icon": "🛍️",
+    "color": "bg-yellow-500",
+    "monthlyBudget": 400,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "cat_bills",
+    "name": "Bills & Utilities",
+    "icon": "⚡",
+    "color": "bg-red-500",
+    "monthlyBudget": 800,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
+    "id": "cat_health",
+    "name": "Healthcare",
+    "icon": "🏥",
+    "color": "bg-pink-500",
+    "monthlyBudget": 150,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  }
+]

--- a/lib/categories/service.ts
+++ b/lib/categories/service.ts
@@ -1,0 +1,420 @@
+import { randomUUID } from "crypto"
+import { readAutomationRules, readCategories, writeAutomationRules, writeCategories } from "@/lib/categories/storage"
+import type {
+  AutomationRule,
+  AutomationRuleWithStats,
+  Category,
+  CategoryWithStats,
+  CreateAutomationRuleInput,
+  CreateCategoryInput,
+  RuleListResult,
+  RuleMatchType,
+  UpdateAutomationRuleInput,
+  UpdateCategoryInput,
+} from "@/lib/categories/types"
+import { readTransactions, writeTransactions } from "@/lib/transactions/storage"
+import type { Transaction } from "@/lib/transactions/types"
+
+type CategoryListParams = {
+  search?: string
+}
+
+type RuleListParams = {
+  search?: string
+}
+
+const RULE_TYPES: RuleMatchType[] = ["contains", "starts_with", "ends_with", "exact", "regex"]
+
+function normalizeName(name: string): string {
+  return name.trim()
+}
+
+function sanitizeBudget(value: number): number {
+  if (!Number.isFinite(value) || Number.isNaN(value)) {
+    return 0
+  }
+  return Math.max(0, Number(value))
+}
+
+function computeCategoryStats(category: Category, transactions: Transaction[]): CategoryWithStats {
+  const relevantTransactions = transactions.filter(
+    (transaction) => transaction.category.toLowerCase() === category.name.toLowerCase(),
+  )
+
+  const spent = relevantTransactions.reduce((total, transaction) => {
+    if (transaction.amount < 0) {
+      return total + Math.abs(transaction.amount)
+    }
+    return total
+  }, 0)
+
+  return {
+    ...category,
+    spent,
+    transactionCount: relevantTransactions.length,
+  }
+}
+
+function matchesPattern(rule: AutomationRule, description: string): boolean {
+  const normalizedDescription = description.toLowerCase()
+  const patterns = rule.pattern
+    .split("|")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  if (patterns.length === 0) {
+    return false
+  }
+
+  switch (rule.type) {
+    case "contains":
+      return patterns.some((pattern) => normalizedDescription.includes(pattern.toLowerCase()))
+    case "starts_with":
+      return patterns.some((pattern) => normalizedDescription.startsWith(pattern.toLowerCase()))
+    case "ends_with":
+      return patterns.some((pattern) => normalizedDescription.endsWith(pattern.toLowerCase()))
+    case "exact":
+      return patterns.some((pattern) => normalizedDescription === pattern.toLowerCase())
+    case "regex":
+      return patterns.some((pattern) => {
+        try {
+          const regex = new RegExp(pattern, "i")
+          return regex.test(description)
+        } catch {
+          return false
+        }
+      })
+    default:
+      return false
+  }
+}
+
+function computeRuleStats(
+  rule: AutomationRule,
+  categoriesById: Map<string, Category>,
+  transactions: Transaction[],
+): AutomationRuleWithStats {
+  const category = categoriesById.get(rule.categoryId)
+  const matchCount = transactions.reduce((count, transaction) => {
+    if (!rule.isActive) {
+      return count
+    }
+    if (!transaction.description) {
+      return count
+    }
+    if (matchesPattern(rule, transaction.description)) {
+      return count + 1
+    }
+    return count
+  }, 0)
+
+  return {
+    ...rule,
+    categoryName: category?.name ?? "Uncategorized",
+    matchCount,
+  }
+}
+
+export async function listCategories(params: CategoryListParams = {}): Promise<CategoryWithStats[]> {
+  const { search } = params
+  const [categories, transactions] = await Promise.all([readCategories(), readTransactions()])
+
+  const normalizedSearch = search?.trim().toLowerCase()
+
+  return categories
+    .map((category) => computeCategoryStats(category, transactions))
+    .filter((category) => {
+      if (!normalizedSearch) {
+        return true
+      }
+      return category.name.toLowerCase().includes(normalizedSearch)
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function createCategory(input: CreateCategoryInput): Promise<CategoryWithStats> {
+  const name = normalizeName(input.name)
+  if (!name) {
+    throw new Error("Category name is required")
+  }
+
+  const categories = await readCategories()
+  const nameExists = categories.some((category) => category.name.toLowerCase() === name.toLowerCase())
+  if (nameExists) {
+    throw new Error("A category with this name already exists")
+  }
+
+  const now = new Date().toISOString()
+  const monthlyBudget = sanitizeBudget(input.monthlyBudget)
+
+  const category: Category = {
+    id: `cat_${randomUUID()}`,
+    name,
+    icon: input.icon,
+    color: input.color,
+    monthlyBudget,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const nextCategories = [...categories, category].sort((a, b) => a.name.localeCompare(b.name))
+  await writeCategories(nextCategories)
+
+  const transactions = await readTransactions()
+  return computeCategoryStats(category, transactions)
+}
+
+export async function updateCategory(id: string, updates: UpdateCategoryInput): Promise<CategoryWithStats> {
+  const categories = await readCategories()
+  const index = categories.findIndex((category) => category.id === id)
+  if (index === -1) {
+    throw new Error("Category not found")
+  }
+
+  const existing = categories[index]
+
+  let name = existing.name
+  if (typeof updates.name === "string") {
+    const normalized = normalizeName(updates.name)
+    if (!normalized) {
+      throw new Error("Category name is required")
+    }
+    const duplicate = categories.some(
+      (category) => category.id !== id && category.name.toLowerCase() === normalized.toLowerCase(),
+    )
+    if (duplicate) {
+      throw new Error("A category with this name already exists")
+    }
+    name = normalized
+  }
+
+  const monthlyBudget =
+    typeof updates.monthlyBudget === "number"
+      ? sanitizeBudget(updates.monthlyBudget)
+      : existing.monthlyBudget
+
+  const updatedCategory: Category = {
+    ...existing,
+    ...updates,
+    name,
+    monthlyBudget,
+    updatedAt: new Date().toISOString(),
+  }
+
+  const nextCategories = [...categories]
+  nextCategories[index] = updatedCategory
+  nextCategories.sort((a, b) => a.name.localeCompare(b.name))
+  await writeCategories(nextCategories)
+
+  if (name !== existing.name) {
+    const transactions = await readTransactions()
+    let hasChanges = false
+    const updatedTransactions = transactions.map((transaction) => {
+      if (transaction.category.toLowerCase() === existing.name.toLowerCase()) {
+        hasChanges = true
+        return {
+          ...transaction,
+          category: updatedCategory.name,
+          updatedAt: new Date().toISOString(),
+        }
+      }
+      return transaction
+    })
+
+    if (hasChanges) {
+      await writeTransactions(updatedTransactions)
+    }
+  }
+
+  const transactions = await readTransactions()
+  return computeCategoryStats(updatedCategory, transactions)
+}
+
+export async function deleteCategory(id: string) {
+  const categories = await readCategories()
+  const category = categories.find((entry) => entry.id === id)
+  if (!category) {
+    throw new Error("Category not found")
+  }
+
+  const remainingCategories = categories.filter((entry) => entry.id !== id)
+  await writeCategories(remainingCategories)
+
+  const transactions = await readTransactions()
+  let hasChanges = false
+  const updatedTransactions = transactions.map((transaction) => {
+    if (transaction.category.toLowerCase() === category.name.toLowerCase()) {
+      hasChanges = true
+      return {
+        ...transaction,
+        category: "Uncategorized",
+        updatedAt: new Date().toISOString(),
+      }
+    }
+    return transaction
+  })
+
+  if (hasChanges) {
+    await writeTransactions(updatedTransactions)
+  }
+
+  const rules = await readAutomationRules()
+  const filteredRules = rules.filter((rule) => rule.categoryId !== id)
+  if (filteredRules.length !== rules.length) {
+    await writeAutomationRules(filteredRules)
+  }
+}
+
+export async function listAutomationRules(params: RuleListParams = {}): Promise<RuleListResult> {
+  const { search } = params
+  const [rules, categories, transactions] = await Promise.all([
+    readAutomationRules(),
+    readCategories(),
+    readTransactions(),
+  ])
+
+  const categoriesById = new Map(categories.map((category) => [category.id, category]))
+  const normalizedSearch = search?.trim().toLowerCase()
+
+  const rulesWithStats = rules
+    .map((rule) => computeRuleStats(rule, categoriesById, transactions))
+    .filter((rule) => {
+      if (!normalizedSearch) {
+        return true
+      }
+      return (
+        rule.name.toLowerCase().includes(normalizedSearch) ||
+        rule.categoryName.toLowerCase().includes(normalizedSearch)
+      )
+    })
+    .sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority
+      }
+      return a.name.localeCompare(b.name)
+    })
+
+  return { rules: rulesWithStats }
+}
+
+export async function createAutomationRule(
+  input: CreateAutomationRuleInput,
+): Promise<AutomationRuleWithStats> {
+  const [rules, categories, transactions] = await Promise.all([
+    readAutomationRules(),
+    readCategories(),
+    readTransactions(),
+  ])
+
+  const category = categories.find((entry) => entry.id === input.categoryId)
+  if (!category) {
+    throw new Error("Selected category does not exist")
+  }
+
+  const name = input.name.trim()
+  if (!name) {
+    throw new Error("Rule name is required")
+  }
+
+  const type = RULE_TYPES.includes(input.type) ? input.type : "contains"
+  const pattern = input.pattern.trim()
+  if (!pattern) {
+    throw new Error("Pattern is required")
+  }
+
+  const priority = Number.isFinite(input.priority) ? Math.max(1, Math.round(input.priority)) : 1
+
+  const now = new Date().toISOString()
+  const rule: AutomationRule = {
+    id: `rule_${randomUUID()}`,
+    name,
+    categoryId: input.categoryId,
+    type,
+    pattern,
+    priority,
+    isActive: Boolean(input.isActive),
+    description: input.description?.trim() || undefined,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const nextRules = [...rules, rule]
+  await writeAutomationRules(nextRules)
+
+  return computeRuleStats(rule, new Map(categories.map((item) => [item.id, item])), transactions)
+}
+
+export async function updateAutomationRule(
+  id: string,
+  updates: UpdateAutomationRuleInput,
+): Promise<AutomationRuleWithStats> {
+  const [rules, categories, transactions] = await Promise.all([
+    readAutomationRules(),
+    readCategories(),
+    readTransactions(),
+  ])
+
+  const index = rules.findIndex((rule) => rule.id === id)
+  if (index === -1) {
+    throw new Error("Rule not found")
+  }
+
+  const existing = rules[index]
+
+  let categoryId = existing.categoryId
+  if (typeof updates.categoryId === "string") {
+    const category = categories.find((entry) => entry.id === updates.categoryId)
+    if (!category) {
+      throw new Error("Selected category does not exist")
+    }
+    categoryId = category.id
+  }
+
+  const type = updates.type && RULE_TYPES.includes(updates.type) ? updates.type : existing.type
+
+  const priority =
+    typeof updates.priority === "number"
+      ? Math.max(1, Math.round(updates.priority))
+      : existing.priority
+
+  const pattern =
+    typeof updates.pattern === "string" && updates.pattern.trim().length > 0
+      ? updates.pattern.trim()
+      : existing.pattern
+
+  let name = existing.name
+  if (typeof updates.name === "string") {
+    const trimmed = updates.name.trim()
+    if (!trimmed) {
+      throw new Error("Rule name is required")
+    }
+    name = trimmed
+  }
+
+  const updatedRule: AutomationRule = {
+    ...existing,
+    ...updates,
+    categoryId,
+    type,
+    priority,
+    pattern,
+    name,
+    description: updates.description?.trim() || existing.description,
+    updatedAt: new Date().toISOString(),
+  }
+
+  const nextRules = [...rules]
+  nextRules[index] = updatedRule
+  await writeAutomationRules(nextRules)
+
+  return computeRuleStats(updatedRule, new Map(categories.map((item) => [item.id, item])), transactions)
+}
+
+export async function deleteAutomationRule(id: string) {
+  const rules = await readAutomationRules()
+  const filtered = rules.filter((rule) => rule.id !== id)
+  if (filtered.length === rules.length) {
+    throw new Error("Rule not found")
+  }
+  await writeAutomationRules(filtered)
+}

--- a/lib/categories/storage.ts
+++ b/lib/categories/storage.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from "fs"
+import path from "path"
+import type { AutomationRule, Category } from "@/lib/categories/types"
+
+const DATA_DIRECTORY = path.join(process.cwd(), "data")
+const CATEGORIES_FILE = path.join(DATA_DIRECTORY, "categories.json")
+const RULES_FILE = path.join(DATA_DIRECTORY, "automation-rules.json")
+
+async function ensureDataFile(filePath: string, fallback: string) {
+  try {
+    await fs.access(filePath)
+  } catch {
+    await fs.mkdir(DATA_DIRECTORY, { recursive: true })
+    await fs.writeFile(filePath, fallback, "utf8")
+  }
+}
+
+export async function readCategories(): Promise<Category[]> {
+  await ensureDataFile(CATEGORIES_FILE, "[]")
+  const contents = await fs.readFile(CATEGORIES_FILE, "utf8")
+  const parsed = JSON.parse(contents) as Category[]
+  return parsed.map((category) => ({
+    ...category,
+    monthlyBudget: Number(category.monthlyBudget) || 0,
+  }))
+}
+
+export async function writeCategories(categories: Category[]) {
+  await ensureDataFile(CATEGORIES_FILE, "[]")
+  await fs.writeFile(CATEGORIES_FILE, JSON.stringify(categories, null, 2), "utf8")
+}
+
+export async function readAutomationRules(): Promise<AutomationRule[]> {
+  await ensureDataFile(RULES_FILE, "[]")
+  const contents = await fs.readFile(RULES_FILE, "utf8")
+  const parsed = JSON.parse(contents) as AutomationRule[]
+  return parsed.map((rule) => ({
+    ...rule,
+    priority: Number(rule.priority) || 1,
+    isActive: Boolean(rule.isActive),
+  }))
+}
+
+export async function writeAutomationRules(rules: AutomationRule[]) {
+  await ensureDataFile(RULES_FILE, "[]")
+  await fs.writeFile(RULES_FILE, JSON.stringify(rules, null, 2), "utf8")
+}

--- a/lib/categories/types.ts
+++ b/lib/categories/types.ts
@@ -1,0 +1,76 @@
+export interface Category {
+  id: string
+  name: string
+  icon: string
+  color: string
+  monthlyBudget: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CategoryWithStats extends Category {
+  spent: number
+  transactionCount: number
+}
+
+export interface CategoryListResult {
+  categories: CategoryWithStats[]
+}
+
+export interface CreateCategoryInput {
+  name: string
+  icon: string
+  color: string
+  monthlyBudget: number
+}
+
+export interface UpdateCategoryInput {
+  name?: string
+  icon?: string
+  color?: string
+  monthlyBudget?: number
+}
+
+export type RuleMatchType = "contains" | "starts_with" | "ends_with" | "exact" | "regex"
+
+export interface AutomationRule {
+  id: string
+  name: string
+  categoryId: string
+  type: RuleMatchType
+  pattern: string
+  priority: number
+  isActive: boolean
+  description?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AutomationRuleWithStats extends AutomationRule {
+  categoryName: string
+  matchCount: number
+}
+
+export interface RuleListResult {
+  rules: AutomationRuleWithStats[]
+}
+
+export interface CreateAutomationRuleInput {
+  name: string
+  categoryId: string
+  type: RuleMatchType
+  pattern: string
+  priority: number
+  isActive: boolean
+  description?: string
+}
+
+export interface UpdateAutomationRuleInput {
+  name?: string
+  categoryId?: string
+  type?: RuleMatchType
+  pattern?: string
+  priority?: number
+  isActive?: boolean
+  description?: string
+}


### PR DESCRIPTION
## Summary
- add category and automation-rule domain modules backed by JSON storage with spending stats
- expose Next.js API routes for listing, mutating, and deleting categories and rules
- replace the categories page dialogs with live CRUD flows that update budgets, categories, and rules

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68cc47d2d9dc8327bc12020001c2b8bc