### PR TITLE
Reapply automation rules after rule changes

### DIFF
--- a/app/api/categories/rules/[id]/route.ts
+++ b/app/api/categories/rules/[id]/route.ts
@@ -21,8 +21,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
     }
 
-    const rule = await updateAutomationRule(params.id, parsed.data)
-    return NextResponse.json({ rule })
+    const { rule, reprocessedCount } = await updateAutomationRule(params.id, parsed.data)
+    return NextResponse.json({ rule, reprocessedCount })
   } catch (error) {
     return NextResponse.json({ error: (error as Error).message }, { status: 500 })
   }

--- a/app/api/categories/rules/route.ts
+++ b/app/api/categories/rules/route.ts
@@ -46,8 +46,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
     }
 
-    const rule = await createAutomationRule(parsed.data as CreateRulePayload)
-    return NextResponse.json({ rule }, { status: 201 })
+    const { rule, reprocessedCount } = await createAutomationRule(parsed.data as CreateRulePayload)
+    return NextResponse.json({ rule, reprocessedCount }, { status: 201 })
   } catch (error) {
     return NextResponse.json({ error: (error as Error).message }, { status: 500 })
   }

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -63,6 +63,16 @@ function sortRules(list: Rule[]) {
   })
 }
 
+function formatReprocessedMessage(count: number) {
+  if (count === 0) {
+    return "No existing transactions were recategorized."
+  }
+  if (count === 1) {
+    return "1 transaction was recategorized."
+  }
+  return `${count} transactions were recategorized.`
+}
+
 export default function CategoriesPage() {
   const [searchTerm, setSearchTerm] = useState("")
   const [categories, setCategories] = useState<Category[]>([])
@@ -397,9 +407,12 @@ export default function CategoriesPage() {
         throw new Error(message)
       }
 
-      const data = (await response.json()) as { rule: Rule }
+      const data = (await response.json()) as { rule: Rule; reprocessedCount: number }
       setRules((previous) => sortRules([...previous, data.rule]))
-      toast.success("Rule created")
+      if (data.reprocessedCount > 0) {
+        void fetchCategories()
+      }
+      toast.success("Rule created", { description: formatReprocessedMessage(data.reprocessedCount) })
     } else if (ruleDialogSelection) {
       const response = await fetch(`/api/categories/rules/${ruleDialogSelection.id}`, {
         method: "PUT",
@@ -413,9 +426,12 @@ export default function CategoriesPage() {
         throw new Error(message)
       }
 
-      const data = (await response.json()) as { rule: Rule }
+      const data = (await response.json()) as { rule: Rule; reprocessedCount: number }
       setRules((previous) => sortRules(previous.map((rule) => (rule.id === data.rule.id ? data.rule : rule))))
-      toast.success("Rule updated")
+      if (data.reprocessedCount > 0) {
+        void fetchCategories()
+      }
+      toast.success("Rule updated", { description: formatReprocessedMessage(data.reprocessedCount) })
     }
   }
 


### PR DESCRIPTION
## Summary
- add a helper to reprocess transactions against automation rules using the shared matcher
- call the helper after creating or updating automation rules and return the recategorized count through the APIs
- surface the recategorization count in the rules UI to inform users when transactions were updated

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc54d239808327b09a5bbf5ac6ed2a