### PR TITLE
Allow settings fetch during password reset and add dark mode toggle

### DIFF
--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -19,7 +19,7 @@ type UpdatePayload = z.infer<typeof updateSchema>
 
 export async function GET() {
   try {
-    await requireSession()
+    await requireSession({ allowPasswordReset: true })
     const settings = await getAppSettings()
     return NextResponse.json({ settings })
   } catch (error) {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { useTheme } from "next-themes"
 import { formatDistanceToNow } from "date-fns"
 import { toast } from "sonner"
 
@@ -40,6 +41,8 @@ export default function SettingsPage() {
   const [passwordLoading, setPasswordLoading] = useState(false)
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
+  const [themeReady, setThemeReady] = useState(false)
+  const { resolvedTheme, setTheme } = useTheme()
 
   useEffect(() => {
     let cancelled = false
@@ -80,6 +83,10 @@ export default function SettingsPage() {
     return () => {
       cancelled = true
     }
+  }, [])
+
+  useEffect(() => {
+    setThemeReady(true)
   }, [])
 
   const mutateSettings = async (patch: Partial<AppSettingsPayload>) => {
@@ -195,6 +202,7 @@ export default function SettingsPage() {
   }
 
   const backupFrequency: BackupFrequency = settings.autoBackupFrequency
+  const canToggleTheme = themeReady && typeof resolvedTheme === "string"
 
   return (
     <AppLayout
@@ -202,6 +210,32 @@ export default function SettingsPage() {
       description="Manage household access, backups, and LAN sync for CashTrack"
     >
       <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Appearance</CardTitle>
+            <CardDescription>Choose between the light and dark interface.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex items-center justify-between">
+            <div>
+              <Label className="text-sm font-medium" htmlFor="dark-mode-toggle">
+                Dark mode
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Switch the dashboard to a darker color palette.
+              </p>
+            </div>
+            <Switch
+              id="dark-mode-toggle"
+              checked={canToggleTheme && resolvedTheme === "dark"}
+              disabled={!canToggleTheme}
+              onCheckedChange={(checked) => {
+                if (!canToggleTheme) return
+                setTheme(checked ? "dark" : "light")
+              }}
+              aria-label="Toggle dark mode"
+            />
+          </CardContent>
+        </Card>
         <Card>
           <CardHeader>
             <CardTitle>Household Account</CardTitle>

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,8 +28,21 @@ function isPublicPath(pathname: string): boolean {
   return PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`))
 }
 
-function isPasswordResetPath(pathname: string): boolean {
-  return pathname.startsWith("/api/users/change-password") || pathname === "/settings"
+function isPasswordResetPath(request: NextRequest): boolean {
+  const { pathname } = request.nextUrl
+  if (pathname === "/settings") {
+    return true
+  }
+  if (pathname.startsWith("/api/users/change-password")) {
+    return true
+  }
+  if (pathname === "/api/settings" && ["GET", "HEAD"].includes(request.method)) {
+    return true
+  }
+  if (pathname === "/api/auth/session" && ["GET", "HEAD"].includes(request.method)) {
+    return true
+  }
+  return false
 }
 
 export async function middleware(request: NextRequest) {
@@ -52,7 +65,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl)
   }
 
-  if (session.user.mustChangePassword && !isPasswordResetPath(pathname)) {
+  if (session.user.mustChangePassword && !isPasswordResetPath(request)) {
     if (isApiRoute) {
       return NextResponse.json({ error: "Password change required" }, { status: 403 })
     }


### PR DESCRIPTION
## Summary
- allow the middleware to pass through settings and session reads while a password reset is required so the settings page can load
- add an appearance section in settings with a dark mode switch powered by next-themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f0cb51b4832780eae77771867008