### PR TITLE
Add household account management, PDF import, and dynamic analytics

### DIFF
--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { listRecentActivity } from "@/lib/activity/repository"
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+
+const querySchema = z.object({
+  limit: z
+    .union([z.string(), z.number()])
+    .transform((value) => Number(value))
+    .optional()
+    .refine((value) => value === undefined || (Number.isFinite(value) && value > 0 && value <= 200), {
+      message: "Limit must be between 1 and 200",
+    }),
+})
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await requireSession()
+    if (session.user?.username !== "household") {
+      return NextResponse.json({ error: "Only the household account can view activity" }, { status: 403 })
+    }
+
+    const url = new URL(request.url)
+    const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams.entries()))
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const limit = parsed.data.limit ?? 50
+    const activities = await listRecentActivity({ limit })
+    return NextResponse.json({ activities })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { getReportAnalytics, type ReportPeriodKey } from "@/lib/reports/analytics"
+
+const querySchema = z.object({
+  period: z.enum(["last-3-months", "last-6-months", "last-12-months", "current-year"]).optional(),
+})
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireSession()
+    const url = new URL(request.url)
+    const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams.entries()))
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const period: ReportPeriodKey = parsed.data.period ?? "last-3-months"
+    const report = await getReportAnalytics(period)
+    return NextResponse.json({ report })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/transactions/import/route.ts
+++ b/app/api/transactions/import/route.ts
@@ -1,33 +1,58 @@
 import { NextRequest, NextResponse } from "next/server"
 import { importTransactions, parseCsvTransactions } from "@/lib/transactions/service"
 import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { parsePdfTransactions } from "@/lib/transactions/pdf-parser"
+import { recordUserAction } from "@/lib/activity/service"
+import type { ParsedCsvTransaction } from "@/lib/transactions/types"
 
 export async function POST(request: NextRequest) {
   try {
-    await requireSession()
+    const session = await requireSession()
     const formData = await request.formData()
     const file = formData.get("file")
     const mappingRaw = formData.get("mapping")
     const dryRun = formData.get("dryRun") === "true"
+    const importTypeRaw = formData.get("importType")
+    const accountNameRaw = formData.get("accountName")
+    const importType = typeof importTypeRaw === "string" ? importTypeRaw.toLowerCase() : ""
+    const accountName = typeof accountNameRaw === "string" ? accountNameRaw : undefined
 
     if (!(file instanceof Blob)) {
       return NextResponse.json({ error: "File is required" }, { status: 400 })
     }
 
-    if (typeof mappingRaw !== "string") {
-      return NextResponse.json({ error: "Column mapping is required" }, { status: 400 })
+    const isPdfImport = importType === "pdf"
+
+    let transactions: ParsedCsvTransaction[]
+    let errors: Array<{ line: number; message: string }>
+
+    if (isPdfImport) {
+      const buffer = Buffer.from(await file.arrayBuffer())
+      const result = await parsePdfTransactions(buffer, { accountName })
+      transactions = result.transactions
+      errors = result.errors
+    } else {
+      if (typeof mappingRaw !== "string") {
+        return NextResponse.json({ error: "Column mapping is required" }, { status: 400 })
+      }
+      const mapping = JSON.parse(mappingRaw)
+      const content = await file.text()
+      const result = parseCsvTransactions(content, mapping)
+      transactions = result.transactions
+      errors = result.errors
     }
-
-    const mapping = JSON.parse(mappingRaw)
-    const content = await file.text()
-
-    const { transactions, errors } = parseCsvTransactions(content, mapping)
 
     if (dryRun) {
       return NextResponse.json({ preview: transactions.slice(0, 20), total: transactions.length, errors })
     }
 
     const result = await importTransactions(transactions)
+    await recordUserAction(session.user, "transaction.import", "transaction", null, {
+      imported: result.imported,
+      skipped: result.skipped,
+      source: isPdfImport ? "pdf" : "csv",
+      errors: errors.length,
+    })
     return NextResponse.json({ ...result, errors })
   } catch (error) {
     if (error instanceof AuthenticationError) {

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "crypto"
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { hashPassword } from "@/lib/auth/passwords"
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { insertUser, listUsers } from "@/lib/users/repository"
+import { recordUserAction } from "@/lib/activity/service"
+
+const createSchema = z.object({
+  username: z
+    .string()
+    .min(3, "Username must be at least 3 characters")
+    .regex(/^[a-zA-Z0-9._-]+$/, "Use letters, numbers, dots, underscores, or dashes"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+  mustChangePassword: z.boolean().optional().default(true),
+})
+
+function sanitizeUser(user: { id: string; username: string; mustChangePassword: boolean; createdAt: string; updatedAt: string }) {
+  return {
+    id: user.id,
+    username: user.username,
+    mustChangePassword: user.mustChangePassword,
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt,
+  }
+}
+
+export async function GET(_request: NextRequest) {
+  try {
+    const session = await requireSession()
+    if (session.user?.username !== "household") {
+      return NextResponse.json({ error: "Only the household account can manage users" }, { status: 403 })
+    }
+
+    const users = await listUsers()
+    return NextResponse.json({ users: users.map(sanitizeUser) })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireSession()
+    if (session.user?.username !== "household") {
+      return NextResponse.json({ error: "Only the household account can create users" }, { status: 403 })
+    }
+
+    const payload = await request.json()
+    const parsed = createSchema.safeParse(payload)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const passwordHash = await hashPassword(parsed.data.password)
+    const user = await insertUser({
+      id: `usr_${randomUUID()}`,
+      username: parsed.data.username,
+      passwordHash,
+      mustChangePassword: parsed.data.mustChangePassword,
+    })
+
+    await recordUserAction(session.user, "user.create", "user", user.id, {
+      username: user.username,
+      mustChangePassword: user.mustChangePassword,
+    })
+
+    return NextResponse.json({ user: sanitizeUser(user) }, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,8 +1,24 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { LucideIcon } from "lucide-react"
+import {
+  AlertTriangle,
+  ArrowDownRight,
+  ArrowUpRight,
+  Calendar,
+  DollarSign,
+  Info,
+  Loader2,
+  Minus,
+  RefreshCcw,
+  Sparkles,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from "lucide-react"
 import { toast } from "sonner"
+
 import { AppLayout } from "@/components/app-layout"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -16,1444 +32,456 @@ import { CategoryTrendChart } from "@/components/charts/category-trend-chart"
 import { IncomeExpenseChart } from "@/components/charts/income-expense-chart"
 import { YearlyComparisonChart } from "@/components/charts/yearly-comparison-chart"
 import { cn } from "@/lib/utils"
-import {
-  AlertTriangle,
-  ArrowDownRight,
-  ArrowUpRight,
-  Calendar,
-  DollarSign,
-  Download,
-  Info,
-  Sparkles,
-  TrendingDown,
-  TrendingUp,
-  Wallet,
-} from "lucide-react"
+import type { ReportAnalytics, ReportPeriodKey } from "@/lib/reports/analytics"
 
-const PERIOD_OPTIONS = [
+const PERIOD_OPTIONS: Array<{ label: string; value: ReportPeriodKey }> = [
   { label: "Last 3 Months", value: "last-3-months" },
   { label: "Last 6 Months", value: "last-6-months" },
   { label: "Last 12 Months", value: "last-12-months" },
   { label: "Current Year", value: "current-year" },
-  { label: "Custom Range", value: "custom" },
-] as const
+]
 
-const CATEGORY_COLOR_CLASSES = [
-  "bg-red-500",
-  "bg-blue-500",
-  "bg-green-500",
-  "bg-yellow-500",
-  "bg-purple-500",
-  "bg-pink-500",
-] as const
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 0,
+})
 
-const CHART_COLOR_PALETTE = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--destructive))",
-] as const
+const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
 
-type ValueFormat = "currency" | "percentage" | "plain"
-type TrendDirection = "up" | "down" | "neutral"
-type InsightVariant = "positive" | "warning" | "info"
-type PeriodKey = (typeof PERIOD_OPTIONS)[number]["value"]
-type BudgetStatus = "ahead" | "on-track" | "behind"
-type RecurringStatus = "due-soon" | "scheduled" | "auto"
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+})
 
-type YearKey = "2024" | "2023" | "2022"
-
-interface SummaryMetric {
-  id: string
-  label: string
-  value: number
-  format?: ValueFormat
+interface SummaryConfig {
   icon: LucideIcon
-  valueClassName?: string
-  change?: number
-  changeDirection?: TrendDirection
-  helper?: string
+  preferLower?: boolean
 }
 
-interface CategoryPerformance {
-  category: string
-  spent: number
-  budget: number
-  change: number
-  transactions: number
-  description?: string
+const SUMMARY_CONFIG: Record<string, SummaryConfig> = {
+  "Total Income": { icon: TrendingUp },
+  "Total Expenses": { icon: TrendingDown, preferLower: true },
+  "Net Savings": { icon: Wallet },
+  "Avg Monthly Spending": { icon: DollarSign, preferLower: true },
 }
 
-interface BudgetHighlight {
-  name: string
-  description: string
-  target: number
-  current: number
-  monthlyContribution: number
-  status: BudgetStatus
-  due: string
+const INSIGHT_STYLES: Record<"positive" | "warning" | "info", { container: string; icon: string }> = {
+  positive: { container: "border-l-4 border-emerald-500 bg-emerald-500/5", icon: "text-emerald-600" },
+  warning: { container: "border-l-4 border-amber-500 bg-amber-500/5", icon: "text-amber-600" },
+  info: { container: "border-l-4 border-sky-500 bg-sky-500/5", icon: "text-sky-600" },
 }
 
-interface RecurringPayment {
-  name: string
-  amount: number
-  schedule: string
-  nextDate: string
-  category: string
-  status: RecurringStatus
+const INSIGHT_ICONS = {
+  positive: Sparkles,
+  warning: AlertTriangle,
+  info: Info,
+} as const
+
+function formatCurrency(value: number) {
+  return currencyFormatter.format(Number.isFinite(value) ? value : 0)
 }
 
-interface Insight {
-  variant: InsightVariant
-  title: string
-  description: string
-}
-
-interface PeriodData {
-  label: string
-  note?: string
-  quickHighlights?: string[]
-  summary: SummaryMetric[]
-  categories: CategoryPerformance[]
-  budgets: BudgetHighlight[]
-  recurring: RecurringPayment[]
-  insights: Insight[]
-}
-
-interface YearlyOverview {
-  totalIncome: number
-  totalExpenses: number
-  totalSavings: number
-  savingsRate: number
-  highlight: string
-  highlights: { label: string; value: string }[]
-  quarters: { quarter: string; income: number; expenses: number; savings: number }[]
-}
-
-const BUDGET_GOALS: BudgetHighlight[] = [
-  {
-    name: "Emergency Fund",
-    description: "Build 6 months of essential expenses.",
-    target: 15000,
-    current: 11250,
-    monthlyContribution: 650,
-    status: "on-track",
-    due: "Dec 2024",
-  },
-  {
-    name: "Vacation Savings",
-    description: "Family trip to Portugal this summer.",
-    target: 5000,
-    current: 3200,
-    monthlyContribution: 450,
-    status: "behind",
-    due: "Aug 2024",
-  },
-  {
-    name: "Education Fund",
-    description: "529 contributions for Ava's college.",
-    target: 7200,
-    current: 5100,
-    monthlyContribution: 600,
-    status: "ahead",
-    due: "Dec 2024",
-  },
-  {
-    name: "Home Office Refresh",
-    description: "Workspace furniture and equipment.",
-    target: 2500,
-    current: 1450,
-    monthlyContribution: 300,
-    status: "on-track",
-    due: "Oct 2024",
-  },
-]
-
-const RECURRING_PAYMENTS: RecurringPayment[] = [
-  {
-    name: "Mortgage & HOA",
-    amount: 1850,
-    schedule: "Monthly",
-    nextDate: "Jun 1, 2024",
-    category: "Housing",
-    status: "due-soon",
-  },
-  {
-    name: "Electric & Gas Utilities",
-    amount: 245,
-    schedule: "Monthly",
-    nextDate: "May 28, 2024",
-    category: "Utilities",
-    status: "due-soon",
-  },
-  {
-    name: "Internet & Streaming Bundle",
-    amount: 128,
-    schedule: "Monthly",
-    nextDate: "Jun 3, 2024",
-    category: "Entertainment",
-    status: "auto",
-  },
-  {
-    name: "Car Insurance",
-    amount: 480,
-    schedule: "Quarterly",
-    nextDate: "Jul 15, 2024",
-    category: "Insurance",
-    status: "scheduled",
-  },
-  {
-    name: "Fitness Membership",
-    amount: 59,
-    schedule: "Monthly",
-    nextDate: "Jun 5, 2024",
-    category: "Wellness",
-    status: "auto",
-  },
-]
-
-const PERIOD_DATA: Record<PeriodKey, PeriodData> = {
-  "last-6-months": {
-    label: "Last 6 Months",
-    note: "Review period: Nov 2023 – Apr 2024 compared with the previous six months.",
-    quickHighlights: [
-      "Housing & Utilities remain largest category ($4,350)",
-      "Savings rate averaged 25.6%",
-      "Shopping exceeded budget by $200",
-    ],
-    summary: [
-      {
-        id: "total-income",
-        label: "Total Income",
-        value: 25200,
-        format: "currency",
-        icon: TrendingUp,
-        valueClassName: "text-green-600",
-        change: 12.5,
-        changeDirection: "up",
-        helper: "Includes salary, bonus, and freelance work.",
-      },
-      {
-        id: "total-expenses",
-        label: "Total Expenses",
-        value: 18750,
-        format: "currency",
-        icon: TrendingDown,
-        valueClassName: "text-red-600",
-        change: -8.2,
-        changeDirection: "down",
-        helper: "After refunds and reimbursements.",
-      },
-      {
-        id: "net-savings",
-        label: "Net Savings",
-        value: 6450,
-        format: "currency",
-        icon: DollarSign,
-        valueClassName: "text-blue-600",
-        change: 18.4,
-        changeDirection: "up",
-        helper: "25.6% savings rate.",
-      },
-      {
-        id: "avg-spend",
-        label: "Avg Monthly Spending",
-        value: 3125,
-        format: "currency",
-        icon: Wallet,
-        change: -4.1,
-        changeDirection: "down",
-        helper: "Based on 6 months of data.",
-      },
-    ],
-    categories: [
-      {
-        category: "Housing & Utilities",
-        spent: 4350,
-        budget: 4500,
-        change: 2.3,
-        transactions: 12,
-        description: "Mortgage, insurance, energy, and services.",
-      },
-      {
-        category: "Food & Dining",
-        spent: 2700,
-        budget: 3000,
-        change: -15.2,
-        transactions: 34,
-        description: "Groceries, restaurants, and delivery.",
-      },
-      {
-        category: "Transportation",
-        spent: 1680,
-        budget: 1800,
-        change: -6.4,
-        transactions: 18,
-        description: "Fuel, maintenance, and ride share.",
-      },
-      {
-        category: "Shopping",
-        spent: 2100,
-        budget: 1900,
-        change: 8.1,
-        transactions: 22,
-        description: "Household and personal purchases.",
-      },
-      {
-        category: "Entertainment",
-        spent: 720,
-        budget: 900,
-        change: 12.5,
-        transactions: 14,
-        description: "Streaming, events, and hobbies.",
-      },
-    ],
-    budgets: BUDGET_GOALS,
-    recurring: RECURRING_PAYMENTS,
-    insights: [
-      {
-        variant: "positive",
-        title: "Dining discipline paying off",
-        description:
-          "Food & dining costs dropped 15% compared with the prior 6 months, keeping you well under budget.",
-      },
-      {
-        variant: "warning",
-        title: "Shopping trending over budget",
-        description:
-          "Discretionary shopping exceeded the allocation by $200. Consider pausing new purchases until next month.",
-      },
-      {
-        variant: "info",
-        title: "Plan upcoming renewals",
-        description:
-          "Car insurance renews in July. Gathering quotes now could reduce recurring expenses before the next billing cycle.",
-      },
-    ],
-  },
-  "last-3-months": {
-    label: "Last 3 Months",
-    note: "Review period: Feb – Apr 2024 compared with the prior quarter.",
-    quickHighlights: [
-      "Three consecutive surplus months",
-      "Groceries 9% under plan",
-      "Ride-share spend +6% vs last quarter",
-    ],
-    summary: [
-      {
-        id: "total-income",
-        label: "Total Income",
-        value: 13200,
-        format: "currency",
-        icon: TrendingUp,
-        valueClassName: "text-green-600",
-        change: 6.2,
-        changeDirection: "up",
-        helper: "Salary and bonus payments received.",
-      },
-      {
-        id: "total-expenses",
-        label: "Total Expenses",
-        value: 9450,
-        format: "currency",
-        icon: TrendingDown,
-        valueClassName: "text-red-600",
-        change: -3.4,
-        changeDirection: "down",
-        helper: "Includes discretionary categories.",
-      },
-      {
-        id: "net-savings",
-        label: "Net Savings",
-        value: 3750,
-        format: "currency",
-        icon: DollarSign,
-        valueClassName: "text-blue-600",
-        change: 11.8,
-        changeDirection: "up",
-        helper: "28.4% savings rate.",
-      },
-      {
-        id: "avg-spend",
-        label: "Avg Monthly Spending",
-        value: 3150,
-        format: "currency",
-        icon: Wallet,
-        change: -2.1,
-        changeDirection: "down",
-        helper: "Based on the last 3 months.",
-      },
-    ],
-    categories: [
-      {
-        category: "Housing & Utilities",
-        spent: 2180,
-        budget: 2250,
-        change: 1.6,
-        transactions: 6,
-        description: "Mortgage, insurance, energy, and services.",
-      },
-      {
-        category: "Food & Dining",
-        spent: 1380,
-        budget: 1500,
-        change: -9.4,
-        transactions: 18,
-        description: "Groceries, restaurants, and delivery.",
-      },
-      {
-        category: "Transportation",
-        spent: 820,
-        budget: 900,
-        change: -3.1,
-        transactions: 9,
-        description: "Fuel, maintenance, and ride share.",
-      },
-      {
-        category: "Shopping",
-        spent: 1080,
-        budget: 950,
-        change: 6.8,
-        transactions: 12,
-        description: "Household and personal purchases.",
-      },
-      {
-        category: "Entertainment",
-        spent: 360,
-        budget: 450,
-        change: 4.5,
-        transactions: 8,
-        description: "Streaming, events, and hobbies.",
-      },
-    ],
-    budgets: BUDGET_GOALS,
-    recurring: RECURRING_PAYMENTS,
-    insights: [
-      {
-        variant: "positive",
-        title: "Savings streak intact",
-        description:
-          "You posted a surplus in each of the last three months while keeping lifestyle spending in check.",
-      },
-      {
-        variant: "warning",
-        title: "Watch discretionary shopping",
-        description:
-          "Shopping outpaced the plan by 13%. Prioritize needs over wants to stay aligned with your budget.",
-      },
-      {
-        variant: "info",
-        title: "Transportation steady",
-        description:
-          "Ride-share use grew slightly. Scheduling preventative maintenance in July could keep costs predictable.",
-      },
-    ],
-  },
-  "last-12-months": {
-    label: "Last 12 Months",
-    note: "Review period: May 2023 – Apr 2024 compared with the prior year.",
-    quickHighlights: [
-      "Annual net savings up $1.6k vs last year",
-      "Entertainment spend trimmed by 12%",
-      "Housing share of spend dropped 2 pts",
-    ],
-    summary: [
-      {
-        id: "total-income",
-        label: "Total Income",
-        value: 50800,
-        format: "currency",
-        icon: TrendingUp,
-        valueClassName: "text-green-600",
-        change: 9.8,
-        changeDirection: "up",
-        helper: "Includes regular and supplemental income.",
-      },
-      {
-        id: "total-expenses",
-        label: "Total Expenses",
-        value: 37800,
-        format: "currency",
-        icon: TrendingDown,
-        valueClassName: "text-red-600",
-        change: -6.1,
-        changeDirection: "down",
-        helper: "Reflects all household categories.",
-      },
-      {
-        id: "net-savings",
-        label: "Net Savings",
-        value: 12600,
-        format: "currency",
-        icon: DollarSign,
-        valueClassName: "text-blue-600",
-        change: 14.3,
-        changeDirection: "up",
-        helper: "24.9% savings rate.",
-      },
-      {
-        id: "avg-spend",
-        label: "Avg Monthly Spending",
-        value: 3150,
-        format: "currency",
-        icon: Wallet,
-        change: -3.4,
-        changeDirection: "down",
-        helper: "Across the last 12 months.",
-      },
-    ],
-    categories: [
-      {
-        category: "Housing & Utilities",
-        spent: 8820,
-        budget: 9000,
-        change: 4.8,
-        transactions: 24,
-        description: "Mortgage, insurance, energy, and services.",
-      },
-      {
-        category: "Food & Dining",
-        spent: 5520,
-        budget: 6000,
-        change: -11.6,
-        transactions: 68,
-        description: "Groceries, restaurants, and delivery.",
-      },
-      {
-        category: "Transportation",
-        spent: 3290,
-        budget: 3600,
-        change: -5.2,
-        transactions: 40,
-        description: "Fuel, maintenance, and ride share.",
-      },
-      {
-        category: "Shopping",
-        spent: 4210,
-        budget: 3800,
-        change: 9.8,
-        transactions: 50,
-        description: "Household and personal purchases.",
-      },
-      {
-        category: "Entertainment",
-        spent: 1420,
-        budget: 1800,
-        change: 8.5,
-        transactions: 32,
-        description: "Streaming, events, and hobbies.",
-      },
-    ],
-    budgets: BUDGET_GOALS,
-    recurring: RECURRING_PAYMENTS,
-    insights: [
-      {
-        variant: "positive",
-        title: "Healthy savings growth",
-        description:
-          "Net savings improved by $1,580 compared with the prior year, keeping you on track for long-term goals.",
-      },
-      {
-        variant: "warning",
-        title: "Shopping continues to climb",
-        description:
-          "Shopping spend rose 9.8% year-over-year. Create spending limits for large purchases to keep it contained.",
-      },
-      {
-        variant: "info",
-        title: "Recurring costs stable",
-        description:
-          "Recurring bills average $2,680 per month. Monitor insurance renewal quotes to avoid increases.",
-      },
-    ],
-  },
-  "current-year": {
-    label: "Current Year",
-    note: "Year-to-date: Jan – May 2024 compared with the same period last year.",
-    quickHighlights: [
-      "Income up 5.6% year-to-date",
-      "Recurring bills holding near $2.3k/mo",
-      "Entertainment trending +6% vs last year",
-    ],
-    summary: [
-      {
-        id: "total-income",
-        label: "Total Income",
-        value: 20850,
-        format: "currency",
-        icon: TrendingUp,
-        valueClassName: "text-green-600",
-        change: 5.6,
-        changeDirection: "up",
-        helper: "Salary, bonus, and side income through May.",
-      },
-      {
-        id: "total-expenses",
-        label: "Total Expenses",
-        value: 15250,
-        format: "currency",
-        icon: TrendingDown,
-        valueClassName: "text-red-600",
-        change: -4.8,
-        changeDirection: "down",
-        helper: "Includes seasonal home expenses.",
-      },
-      {
-        id: "net-savings",
-        label: "Net Savings",
-        value: 5600,
-        format: "currency",
-        icon: DollarSign,
-        valueClassName: "text-blue-600",
-        change: 9.2,
-        changeDirection: "up",
-        helper: "25.8% savings rate.",
-      },
-      {
-        id: "avg-spend",
-        label: "Avg Monthly Spending",
-        value: 3050,
-        format: "currency",
-        icon: Wallet,
-        change: -3.2,
-        changeDirection: "down",
-        helper: "Through the first five months.",
-      },
-    ],
-    categories: [
-      {
-        category: "Housing & Utilities",
-        spent: 3620,
-        budget: 3800,
-        change: 2.1,
-        transactions: 8,
-        description: "Mortgage, insurance, energy, and services.",
-      },
-      {
-        category: "Food & Dining",
-        spent: 1980,
-        budget: 2200,
-        change: -10.6,
-        transactions: 22,
-        description: "Groceries, restaurants, and delivery.",
-      },
-      {
-        category: "Transportation",
-        spent: 1180,
-        budget: 1250,
-        change: -4.2,
-        transactions: 12,
-        description: "Fuel, maintenance, and ride share.",
-      },
-      {
-        category: "Shopping",
-        spent: 1560,
-        budget: 1500,
-        change: 5.9,
-        transactions: 16,
-        description: "Household and personal purchases.",
-      },
-      {
-        category: "Entertainment",
-        spent: 540,
-        budget: 650,
-        change: 6.1,
-        transactions: 10,
-        description: "Streaming, events, and hobbies.",
-      },
-    ],
-    budgets: BUDGET_GOALS,
-    recurring: RECURRING_PAYMENTS,
-    insights: [
-      {
-        variant: "positive",
-        title: "YTD savings ahead of plan",
-        description:
-          "Net savings are pacing $460 above your target. Keep contributions steady to maintain momentum through summer.",
-      },
-      {
-        variant: "warning",
-        title: "Shopping slightly elevated",
-        description:
-          "Retail spending is 4% higher than last year. Delay non-essential upgrades until July to stay aligned with goals.",
-      },
-      {
-        variant: "info",
-        title: "Utility costs steady",
-        description:
-          "Utility charges have remained flat for three months. Consider negotiating the internet bundle ahead of fall promos.",
-      },
-    ],
-  },
-  custom: {
-    label: "Custom Range",
-    note: "Custom range: Mar 1 – Apr 15, 2024 compared with the previous six weeks.",
-    quickHighlights: [
-      "Large appliance purchase on Mar 18",
-      "Utilities trending 5% above seasonal average",
-      "Dining out under budget for six weeks straight",
-    ],
-    summary: [
-      {
-        id: "total-income",
-        label: "Total Income",
-        value: 9800,
-        format: "currency",
-        icon: TrendingUp,
-        valueClassName: "text-green-600",
-        change: 4.2,
-        changeDirection: "up",
-        helper: "One-time project payment included.",
-      },
-      {
-        id: "total-expenses",
-        label: "Total Expenses",
-        value: 7450,
-        format: "currency",
-        icon: TrendingDown,
-        valueClassName: "text-red-600",
-        change: -3.6,
-        changeDirection: "down",
-        helper: "Reflects the custom filtered dates.",
-      },
-      {
-        id: "net-savings",
-        label: "Net Savings",
-        value: 2350,
-        format: "currency",
-        icon: DollarSign,
-        valueClassName: "text-blue-600",
-        change: 7.1,
-        changeDirection: "up",
-        helper: "24.0% savings rate.",
-      },
-      {
-        id: "avg-spend",
-        label: "Avg Monthly Spending",
-        value: 3100,
-        format: "currency",
-        icon: Wallet,
-        change: -1.9,
-        changeDirection: "down",
-        helper: "Custom range trendline.",
-      },
-    ],
-    categories: [
-      {
-        category: "Housing & Utilities",
-        spent: 1450,
-        budget: 1500,
-        change: 0.9,
-        transactions: 3,
-        description: "Mortgage, insurance, energy, and services.",
-      },
-      {
-        category: "Food & Dining",
-        spent: 980,
-        budget: 1050,
-        change: -8.2,
-        transactions: 10,
-        description: "Groceries, restaurants, and delivery.",
-      },
-      {
-        category: "Transportation",
-        spent: 510,
-        budget: 540,
-        change: -2.5,
-        transactions: 6,
-        description: "Fuel, maintenance, and ride share.",
-      },
-      {
-        category: "Shopping",
-        spent: 720,
-        budget: 650,
-        change: 6.5,
-        transactions: 7,
-        description: "Household and personal purchases.",
-      },
-      {
-        category: "Entertainment",
-        spent: 240,
-        budget: 300,
-        change: 3.2,
-        transactions: 4,
-        description: "Streaming, events, and hobbies.",
-      },
-    ],
-    budgets: BUDGET_GOALS,
-    recurring: RECURRING_PAYMENTS,
-    insights: [
-      {
-        variant: "positive",
-        title: "Custom range within limits",
-        description:
-          "The selected dates still delivered a surplus thanks to lower dining and transportation costs.",
-      },
-      {
-        variant: "warning",
-        title: "Spotlight on recent shopping",
-        description:
-          "A new appliance purchase drove shopping above plan. Schedule a budget review before the next big expense.",
-      },
-      {
-        variant: "info",
-        title: "Monitor utility usage",
-        description:
-          "Utilities ran 5% higher than seasonal norms. Smart thermostat adjustments could offset the increase.",
-      },
-    ],
-  },
-}
-
-const YEARLY_OVERVIEW: Record<YearKey, YearlyOverview> = {
-  "2024": {
-    totalIncome: 50800,
-    totalExpenses: 37250,
-    totalSavings: 13550,
-    savingsRate: 26.6,
-    highlight: "Trending 7% higher savings than 2023 year-to-date.",
-    highlights: [
-      { label: "Best Month", value: "April ($1,240 net)" },
-      { label: "Top Category", value: "Housing & Utilities (28%)" },
-      { label: "Avg Monthly Net", value: "$1,129" },
-    ],
-    quarters: [
-      { quarter: "Q1", income: 12600, expenses: 9450, savings: 3150 },
-      { quarter: "Q2", income: 12400, expenses: 9300, savings: 3100 },
-      { quarter: "Q3", income: 13000, expenses: 9700, savings: 3300 },
-      { quarter: "Q4", income: 12800, expenses: 8800, savings: 4000 },
-    ],
-  },
-  "2023": {
-    totalIncome: 47800,
-    totalExpenses: 36450,
-    totalSavings: 11350,
-    savingsRate: 23.7,
-    highlight: "Savings rate improved 2.4 pts compared with 2022.",
-    highlights: [
-      { label: "Best Month", value: "November ($1,180 net)" },
-      { label: "Top Category", value: "Food & Dining (18%)" },
-      { label: "Avg Monthly Net", value: "$946" },
-    ],
-    quarters: [
-      { quarter: "Q1", income: 11600, expenses: 8650, savings: 2950 },
-      { quarter: "Q2", income: 11700, expenses: 9100, savings: 2600 },
-      { quarter: "Q3", income: 12200, expenses: 9500, savings: 2700 },
-      { quarter: "Q4", income: 12300, expenses: 9200, savings: 3100 },
-    ],
-  },
-  "2022": {
-    totalIncome: 45200,
-    totalExpenses: 35420,
-    totalSavings: 9780,
-    savingsRate: 21.6,
-    highlight: "Baseline year after reorganizing budgets.",
-    highlights: [
-      { label: "Best Month", value: "July ($980 net)" },
-      { label: "Top Category", value: "Transportation (15%)" },
-      { label: "Avg Monthly Net", value: "$815" },
-    ],
-    quarters: [
-      { quarter: "Q1", income: 10800, expenses: 8400, savings: 2400 },
-      { quarter: "Q2", income: 11050, expenses: 8850, savings: 2200 },
-      { quarter: "Q3", income: 11600, expenses: 9050, savings: 2550 },
-      { quarter: "Q4", income: 11750, expenses: 9120, savings: 2630 },
-    ],
-  },
-}
-
-const DEFAULT_PERIOD: PeriodKey = "last-6-months"
-const DEFAULT_YEAR: YearKey = "2024"
-
-const changeBadgeStyles: Record<TrendDirection, string> = {
-  up: "bg-green-50 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-200 dark:border-green-900",
-  down: "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-200 dark:border-red-900",
-  neutral: "bg-muted text-muted-foreground border-muted",
-}
-
-const budgetStatusStyles: Record<BudgetStatus, { label: string; className: string }> = {
-  ahead: {
-    label: "Ahead",
-    className:
-      "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-200 dark:border-emerald-900",
-  },
-  "on-track": {
-    label: "On Track",
-    className: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-900",
-  },
-  behind: {
-    label: "Needs Attention",
-    className: "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-200 dark:border-amber-900",
-  },
-}
-
-const recurringStatusStyles: Record<RecurringStatus, { label: string; className: string }> = {
-  "due-soon": {
-    label: "Due Soon",
-    className: "bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-200 dark:border-orange-900",
-  },
-  scheduled: {
-    label: "Scheduled",
-    className: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-900",
-  },
-  auto: {
-    label: "Auto-pay",
-    className: "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950 dark:text-emerald-200 dark:border-emerald-900",
-  },
-}
-
-const insightStyleMap: Record<InsightVariant, { container: string; badge: string; title: string; description: string; icon: LucideIcon }> = {
-  positive: {
-    container: "bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-900",
-    badge: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200",
-    title: "text-green-800 dark:text-green-200",
-    description: "text-green-700 dark:text-green-300",
-    icon: Sparkles,
-  },
-  warning: {
-    container: "bg-amber-50 border-amber-200 dark:bg-amber-950 dark:border-amber-900",
-    badge: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-200",
-    title: "text-amber-800 dark:text-amber-200",
-    description: "text-amber-700 dark:text-amber-300",
-    icon: AlertTriangle,
-  },
-  info: {
-    container: "bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-900",
-    badge: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200",
-    title: "text-blue-800 dark:text-blue-200",
-    description: "text-blue-700 dark:text-blue-300",
-    icon: Info,
-  },
-}
-
-function formatCurrency(
-  value: number,
-  { minimumFractionDigits = 2, maximumFractionDigits = 2 }: { minimumFractionDigits?: number; maximumFractionDigits?: number } = {},
-) {
-  return `$${value.toLocaleString(undefined, { minimumFractionDigits, maximumFractionDigits })}`
-}
-
-function formatPercentage(value: number, fractionDigits = 1) {
-  return `${value.toFixed(fractionDigits)}%`
-}
-
-function formatValue(value: number, format: ValueFormat = "currency") {
-  switch (format) {
-    case "percentage":
-      return formatPercentage(value)
-    case "plain":
-      return value.toLocaleString()
-    case "currency":
-    default:
-      return formatCurrency(value)
+function formatChange(value: number | null, preferLower = false) {
+  if (value === null || Number.isNaN(value)) {
+    return { label: "No comparison", display: "—", className: "text-muted-foreground" }
   }
+
+  const formatted = `${value > 0 ? "+" : ""}${value.toFixed(1)}%`
+  if (value === 0) {
+    return { label: "No change", display: formatted, className: "text-muted-foreground" }
+  }
+
+  const isPositive = preferLower ? value < 0 : value > 0
+  return {
+    label: isPositive ? "Improved" : "Declined",
+    display: formatted,
+    className: isPositive ? "text-emerald-600" : "text-red-600",
+  }
+}
+
+function parseIsoDate(value: string): Date | null {
+  if (!value) return null
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function formatDateRange(start: string, end: string) {
+  const startDate = parseIsoDate(start)
+  const endDate = parseIsoDate(end)
+  if (!startDate || !endDate) {
+    return `${start} – ${end}`
+  }
+
+  const inclusiveEnd = new Date(endDate.getTime() - 86_400_000)
+  return `${dateFormatter.format(startDate)} – ${dateFormatter.format(inclusiveEnd)}`
+}
+
+interface ReportsResponse {
+  report?: ReportAnalytics
+  error?: unknown
 }
 
 export default function ReportsPage() {
-  const [selectedPeriod, setSelectedPeriod] = useState<PeriodKey>(DEFAULT_PERIOD)
-  const [selectedYear, setSelectedYear] = useState<YearKey>(DEFAULT_YEAR)
+  const [period, setPeriod] = useState<ReportPeriodKey>("last-3-months")
+  const [report, setReport] = useState<ReportAnalytics | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshToken, setRefreshToken] = useState(0)
 
-  const periodData = PERIOD_DATA[selectedPeriod] ?? PERIOD_DATA[DEFAULT_PERIOD]
-  const yearData = YEARLY_OVERVIEW[selectedYear] ?? YEARLY_OVERVIEW[DEFAULT_YEAR]
+  useEffect(() => {
+    const controller = new AbortController()
+    let isMounted = true
 
-  const categoriesWithColor = useMemo(() => {
-    const total = periodData.categories.reduce((acc, category) => acc + category.spent, 0)
-    return periodData.categories.map((category, index) => {
-      const colorClass = CATEGORY_COLOR_CLASSES[index % CATEGORY_COLOR_CLASSES.length]
-      const chartColor = CHART_COLOR_PALETTE[index % CHART_COLOR_PALETTE.length]
-      const percentage = total > 0 ? (category.spent / total) * 100 : 0
-      return { ...category, colorClass, chartColor, percentage }
-    })
-  }, [periodData])
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await fetch(`/api/reports?period=${period}`, {
+          cache: "no-store",
+          signal: controller.signal,
+        })
 
-  const monthlyChartData = useMemo(
-    () =>
-      categoriesWithColor.map((category) => ({
-        name: category.category,
-        value: category.spent,
-        color: category.chartColor,
-      })),
-    [categoriesWithColor],
-  )
+        if (!response.ok) {
+          const body = (await response.json().catch(() => ({}))) as ReportsResponse
+          const message = typeof body.error === "string" ? body.error : "Unable to load report"
+          throw new Error(message)
+        }
 
-  const recurringTotal = useMemo(
-    () => periodData.recurring.reduce((sum, payment) => sum + payment.amount, 0),
-    [periodData],
-  )
+        const body = (await response.json()) as ReportsResponse
+        if (!body.report) {
+          throw new Error("No analytics were returned")
+        }
 
-  const handleExport = (format: "pdf" | "csv") => {
-    toast.success("Export requested", {
-      description: `${periodData.label} report (${format.toUpperCase()}) will be generated shortly.`,
-    })
+        if (isMounted) {
+          setReport(body.report)
+        }
+      } catch (fetchError) {
+        if (fetchError instanceof DOMException && fetchError.name === "AbortError") {
+          return
+        }
+
+        const message = fetchError instanceof Error ? fetchError.message : "Unable to load report"
+        if (isMounted) {
+          setError(message)
+        }
+        toast.error("Unable to load report", { description: message })
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+    return () => {
+      isMounted = false
+      controller.abort()
+    }
+  }, [period, refreshToken])
+
+  const handleRefresh = () => {
+    setRefreshToken((token) => token + 1)
   }
 
+  const handlePeriodChange = (value: string) => {
+    setPeriod(value as ReportPeriodKey)
+  }
+
+  const categoryRows = useMemo(() => {
+    if (!report) return []
+    return report.categories.map((category) => {
+      const budget = Number(category.budget ?? 0)
+      const spent = Number(category.spent ?? 0)
+      const transactions = Number(category.transactions ?? 0)
+      const usagePercent = budget > 0 ? (spent / budget) * 100 : null
+      const overBudget = budget > 0 && spent > budget
+      const change = category.change
+      return { category, budget, spent, transactions, usagePercent, overBudget, change }
+    })
+  }, [report])
+
+  const currentYearLabels = useMemo(() => {
+    if (!report) {
+      return { current: "Current", previous: "Previous" }
+    }
+    const startDate = parseIsoDate(report.startDate)
+    if (!startDate) {
+      return { current: "Current", previous: "Previous" }
+    }
+    const currentYear = startDate.getUTCFullYear()
+    return { current: currentYear.toString(), previous: (currentYear - 1).toString() }
+  }, [report])
+
   return (
-    <AppLayout
-      title="Reports & Analytics"
-      description="Detailed insights into your spending patterns"
-      action={
-        <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => handleExport("csv")}>
-            <Download className="mr-2 h-4 w-4" />
-            Export CSV
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => handleExport("pdf")}>
-            <Download className="mr-2 h-4 w-4" />
-            Export PDF
-          </Button>
-        </div>
-      }
-    >
+    <AppLayout>
       <div className="space-y-6">
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div className="flex items-center gap-2">
-                <Calendar className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm font-medium">Time Period</span>
-              </div>
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <Select value={selectedPeriod} onValueChange={(value) => setSelectedPeriod(value as PeriodKey)}>
-                  <SelectTrigger className="w-[200px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PERIOD_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select value={selectedYear} onValueChange={(value) => setSelectedYear(value as YearKey)}>
-                  <SelectTrigger className="w-[120px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(["2024", "2023", "2022"] as YearKey[]).map((year) => (
-                      <SelectItem key={year} value={year}>
-                        {year}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <div>
+              <h1 className="text-2xl font-semibold tracking-tight">Reports &amp; Analytics</h1>
+              <p className="text-sm text-muted-foreground">
+                Monitor how your household spending trends evolve over time and identify opportunities to save more.
+              </p>
             </div>
-            {periodData.note && <p className="text-xs text-muted-foreground">{periodData.note}</p>}
-            {periodData.quickHighlights && (
-              <div className="flex flex-wrap gap-2">
-                {periodData.quickHighlights.map((highlight) => (
-                  <Badge
-                    key={highlight}
-                    variant="outline"
-                    className="border-dashed bg-muted/40 text-xs font-medium text-muted-foreground"
-                  >
-                    {highlight}
-                  </Badge>
-                ))}
+            {report && (
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <Badge variant="secondary" className="rounded-full">
+                  {report.label}
+                </Badge>
+                <span className="flex items-center gap-1">
+                  <Calendar className="h-3.5 w-3.5" />
+                  {formatDateRange(report.startDate, report.endDate)}
+                </span>
               </div>
             )}
-          </CardContent>
-        </Card>
-
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          {periodData.summary.map((metric) => {
-            const Icon = metric.icon
-            const direction = metric.changeDirection ?? "neutral"
-            const changeValue = Math.abs(metric.change ?? 0).toFixed(1)
-            const changePrefix = direction === "down" ? "-" : direction === "neutral" ? "±" : "+"
-            return (
-              <Card key={metric.id}>
-                <CardHeader className="space-y-2 pb-2">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-sm font-medium">{metric.label}</CardTitle>
-                    <Icon className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  {metric.change !== undefined && (
-                    <Badge variant="outline" className={cn("flex items-center gap-1 border-0", changeBadgeStyles[direction])}>
-                      {direction === "down" ? (
-                        <ArrowDownRight className="h-3 w-3" />
-                      ) : (
-                        <ArrowUpRight className="h-3 w-3" />
-                      )}
-                      <span>{`${changePrefix}${changeValue}%`}</span>
-                    </Badge>
-                  )}
-                </CardHeader>
-                <CardContent>
-                  <div className={cn("text-2xl font-bold", metric.valueClassName)}>{formatValue(metric.value, metric.format)}</div>
-                  {metric.helper && <p className="text-xs text-muted-foreground">{metric.helper}</p>}
-                </CardContent>
-              </Card>
-            )
-          })}
-        </div>
-
-        <Tabs defaultValue="monthly" className="space-y-4">
-          <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="monthly">Monthly Breakdown</TabsTrigger>
-            <TabsTrigger value="trends">Category Trends</TabsTrigger>
-            <TabsTrigger value="income-expense">Income vs Expense</TabsTrigger>
-            <TabsTrigger value="yearly">Yearly Comparison</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="monthly" className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Monthly Spending Breakdown</CardTitle>
-                  <CardDescription>Spending by category for the selected period</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <MonthlyBreakdownChart data={monthlyChartData} />
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Top Categories</CardTitle>
-                  <CardDescription>Highest spending categories</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-4">
-                    {categoriesWithColor.map((item) => (
-                      <div key={item.category} className="flex items-start justify-between gap-4">
-                        <div className="flex items-start gap-3">
-                          <div className={cn("mt-1 h-3 w-3 rounded-full", item.colorClass)} />
-                          <div>
-                            <p className="text-sm font-medium leading-tight">{item.category}</p>
-                            {item.description && (
-                              <p className="text-xs text-muted-foreground">{item.description}</p>
-                            )}
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-medium">{formatCurrency(item.spent)}</div>
-                          <div className="text-xs text-muted-foreground">{item.percentage.toFixed(1)}% of total</div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="trends" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Category Spending Trends</CardTitle>
-                <CardDescription>How your spending in each category has changed over time</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <CategoryTrendChart />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="income-expense" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Income vs Expenses</CardTitle>
-                <CardDescription>Monthly comparison of income and expenses</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <IncomeExpenseChart />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="yearly" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Year-over-Year Comparison</CardTitle>
-                <CardDescription>Compare spending patterns across different years</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <YearlyComparisonChart />
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-
-        <div className="grid gap-4 lg:grid-cols-7">
-          <Card className="lg:col-span-4">
-            <CardHeader>
-              <CardTitle>Category performance</CardTitle>
-              <CardDescription>Budget adherence for each major category</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Category</TableHead>
-                    <TableHead>Spent</TableHead>
-                    <TableHead>Variance</TableHead>
-                    <TableHead>Change</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {categoriesWithColor.map((category) => {
-                    const variance = category.budget - category.spent
-                    const variancePositive = variance >= 0
-                    const barWidth = category.budget > 0 ? Math.min((category.spent / category.budget) * 100, 100) : 0
-                    return (
-                      <TableRow key={category.category}>
-                        <TableCell>
-                          <div className="space-y-1">
-                            <p className="text-sm font-medium leading-tight">{category.category}</p>
-                            <p className="text-xs text-muted-foreground">
-                              {category.transactions} transactions • {formatCurrency(category.budget, {
-                                minimumFractionDigits: 0,
-                                maximumFractionDigits: 0,
-                              })}{" "}
-                              budget
-                            </p>
-                          </div>
-                        </TableCell>
-                        <TableCell className="w-[220px]">
-                          <div className="text-sm font-medium">{formatCurrency(category.spent)}</div>
-                          <div className="mt-2 h-2 w-full rounded-full bg-secondary">
-                            <div
-                              className={cn(
-                                "h-2 rounded-full",
-                                category.spent > category.budget
-                                  ? "bg-red-500"
-                                  : category.spent / category.budget < 0.6
-                                    ? "bg-emerald-500"
-                                    : "bg-primary",
-                              )}
-                              style={{ width: `${barWidth}%` }}
-                            />
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <div
-                            className={cn(
-                              "text-sm font-medium",
-                              variancePositive ? "text-green-600" : "text-red-600",
-                            )}
-                          >
-                            {variancePositive ? "+" : "-"}
-                            {formatCurrency(Math.abs(variance), {
-                              minimumFractionDigits: 0,
-                              maximumFractionDigits: 0,
-                            })}
-                          </div>
-                          <p className="text-xs text-muted-foreground">Remaining from budget</p>
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant="outline"
-                            className={cn(
-                              "flex items-center gap-1 border-0",
-                              category.change >= 0
-                                ? "bg-green-50 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-200 dark:border-green-900"
-                                : "bg-red-50 text-red-700 border-red-200 dark:bg-red-950 dark:text-red-200 dark:border-red-900",
-                            )}
-                          >
-                            {category.change >= 0 ? (
-                              <ArrowUpRight className="h-3 w-3" />
-                            ) : (
-                              <ArrowDownRight className="h-3 w-3" />
-                            )}
-                            {`${category.change >= 0 ? "+" : "-"}${Math.abs(category.change).toFixed(1)}%`}
-                          </Badge>
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
-          <div className="space-y-4 lg:col-span-3">
-            <Card>
-              <CardHeader>
-                <CardTitle>Goal tracking</CardTitle>
-                <CardDescription>Progress toward savings objectives</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  {periodData.budgets.map((budget, index) => {
-                    const status = budgetStatusStyles[budget.status]
-                    const progress = budget.target > 0 ? Math.min((budget.current / budget.target) * 100, 100) : 0
-                    return (
-                      <div key={budget.name} className={cn("space-y-2", index > 0 && "border-t pt-4")}> 
-                        <div className="flex items-start justify-between">
-                          <div>
-                            <p className="text-sm font-medium">{budget.name}</p>
-                            <p className="text-xs text-muted-foreground">{budget.description}</p>
-                          </div>
-                          <Badge variant="outline" className={cn("border-0", status.className)}>
-                            {status.label}
-                          </Badge>
-                        </div>
-                        <div className="flex items-center justify-between text-xs text-muted-foreground">
-                          <span>
-                            {formatCurrency(budget.current, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} saved
-                          </span>
-                          <span>
-                            {formatCurrency(budget.target, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} goal
-                          </span>
-                        </div>
-                        <div className="h-2 w-full rounded-full bg-secondary">
-                          <div
-                            className={cn(
-                              "h-2 rounded-full",
-                              budget.status === "behind"
-                                ? "bg-amber-500"
-                                : budget.status === "ahead"
-                                  ? "bg-emerald-500"
-                                  : "bg-primary",
-                            )}
-                            style={{ width: `${progress}%` }}
-                          />
-                        </div>
-                        <p className="text-xs text-muted-foreground">
-                          Contributing {formatCurrency(budget.monthlyContribution, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
-                          /mo • Target {budget.due}
-                        </p>
-                      </div>
-                    )
-                  })}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Upcoming recurring charges</CardTitle>
-                <CardDescription>
-                  Charges scheduled this cycle total {formatCurrency(recurringTotal, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3">
-                  {periodData.recurring.map((payment) => {
-                    const status = recurringStatusStyles[payment.status]
-                    return (
-                      <div
-                        key={payment.name}
-                        className="flex items-start justify-between gap-3 rounded-lg border bg-background/60 p-3 dark:bg-muted/20"
-                      >
-                        <div className="space-y-1">
-                          <p className="text-sm font-medium leading-tight">{payment.name}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {payment.category} • {payment.schedule}
-                          </p>
-                          <p className="text-xs text-muted-foreground">Next charge {payment.nextDate}</p>
-                        </div>
-                        <div className="text-right">
-                          <div className="font-semibold">{formatCurrency(payment.amount)}</div>
-                          <Badge variant="outline" className={cn("mt-2 border-0", status.className)}>
-                            {status.label}
-                          </Badge>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
-              </CardContent>
-            </Card>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Select value={period} onValueChange={handlePeriodChange}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Select period" />
+              </SelectTrigger>
+              <SelectContent>
+                {PERIOD_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button variant="outline" size="sm" onClick={handleRefresh} disabled={loading}>
+              {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCcw className="mr-2 h-4 w-4" />}
+              Refresh
+            </Button>
           </div>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>{selectedYear} snapshot</CardTitle>
-            <CardDescription>{yearData.highlight}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-3">
+        {error && (
+          <Card className="border-amber-500/30 bg-amber-500/5">
+            <CardContent className="flex items-start gap-3 py-4 text-sm">
+              <AlertTriangle className="mt-0.5 h-4 w-4 text-amber-600" />
               <div>
-                <p className="text-xs font-medium uppercase text-muted-foreground">Total Income</p>
-                <p className="text-lg font-semibold">{formatCurrency(yearData.totalIncome)}</p>
-              </div>
-              <div>
-                <p className="text-xs font-medium uppercase text-muted-foreground">Total Expenses</p>
-                <p className="text-lg font-semibold">{formatCurrency(yearData.totalExpenses)}</p>
-              </div>
-              <div>
-                <p className="text-xs font-medium uppercase text-muted-foreground">Total Savings</p>
-                <p className="text-lg font-semibold text-green-600 dark:text-green-300">
-                  {formatCurrency(yearData.totalSavings)}
+                <p className="font-medium text-amber-900 dark:text-amber-200">{error}</p>
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  Try refreshing the report or selecting a different time period.
                 </p>
               </div>
-            </div>
-            <div className="rounded-lg border bg-muted/30 p-4">
-              <div className="flex items-center justify-between text-sm font-medium">
-                <span>Savings rate</span>
-                <span className="text-green-600 dark:text-green-300">{formatPercentage(yearData.savingsRate)}</span>
-              </div>
-              <Progress value={Math.min(yearData.savingsRate, 100)} className="mt-2 h-2" />
-              <p className="mt-2 text-xs text-muted-foreground">Goal: 30% yearly savings rate</p>
-            </div>
-            <div className="grid gap-3 sm:grid-cols-3">
-              {yearData.highlights.map((item) => (
-                <div key={item.label} className="rounded-md border bg-background/40 p-3 dark:bg-muted/20">
-                  <p className="text-xs font-medium text-muted-foreground uppercase">{item.label}</p>
-                  <p className="mt-1 text-sm font-semibold">{item.value}</p>
-                </div>
-              ))}
-            </div>
-            <div className="overflow-hidden rounded-lg border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Quarter</TableHead>
-                    <TableHead>Income</TableHead>
-                    <TableHead>Expenses</TableHead>
-                    <TableHead>Savings</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {yearData.quarters.map((quarter) => (
-                    <TableRow key={quarter.quarter}>
-                      <TableCell className="font-medium">{quarter.quarter}</TableCell>
-                      <TableCell>{formatCurrency(quarter.income)}</TableCell>
-                      <TableCell>{formatCurrency(quarter.expenses)}</TableCell>
-                      <TableCell className="text-green-600 dark:text-green-300">
-                        {formatCurrency(quarter.savings)}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Financial insights</CardTitle>
-            <CardDescription>{periodData.label} summary insights</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {periodData.insights.map((insight) => {
-                const style = insightStyleMap[insight.variant]
-                const Icon = style.icon
+        {!report && loading && (
+          <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading analytics…
+          </div>
+        )}
+
+        {report && (
+          <>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              {report.summary.map((metric) => {
+                const config = SUMMARY_CONFIG[metric.label] ?? { icon: Info }
+                const changeDetails = formatChange(metric.change, config.preferLower)
+                const DirectionIcon =
+                  metric.direction === "up" ? ArrowUpRight : metric.direction === "down" ? ArrowDownRight : Minus
+                const MetricIcon = config.icon
+
                 return (
-                  <div key={insight.title} className={cn("rounded-lg border p-4", style.container)}>
-                    <div className="flex items-start gap-3">
-                      <div className={cn("mt-1 rounded-full p-2", style.badge)}>
-                        <Icon className="h-4 w-4" />
+                  <Card key={metric.label} className="shadow-sm">
+                    <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+                      <div className="space-y-1">
+                        <CardTitle className="text-sm font-medium text-muted-foreground">{metric.label}</CardTitle>
+                        {metric.helper && <CardDescription className="text-xs">{metric.helper}</CardDescription>}
                       </div>
-                      <div>
-                        <p className={cn("text-sm font-semibold", style.title)}>{insight.title}</p>
-                        <p className={cn("mt-1 text-sm", style.description)}>{insight.description}</p>
+                      <MetricIcon className="h-4 w-4 text-muted-foreground" />
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <div className="text-2xl font-semibold tracking-tight">{formatCurrency(metric.value)}</div>
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className={cn("inline-flex items-center gap-1 font-medium", changeDetails.className)}>
+                          <DirectionIcon className="h-3 w-3" />
+                          {changeDetails.display}
+                        </span>
+                        <span className="text-muted-foreground">{changeDetails.label}</span>
                       </div>
-                    </div>
-                  </div>
+                    </CardContent>
+                  </Card>
                 )
               })}
             </div>
-          </CardContent>
-        </Card>
+
+            <div className="grid gap-4 lg:grid-cols-3">
+              <Card className="lg:col-span-2">
+                <CardHeader>
+                  <CardTitle>Spending breakdown</CardTitle>
+                  <CardDescription>Compare categories, monthly trends, and income versus expenses.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Tabs defaultValue="categories" className="space-y-4">
+                    <TabsList className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                      <TabsTrigger value="categories">Top categories</TabsTrigger>
+                      <TabsTrigger value="trend">Category trend</TabsTrigger>
+                      <TabsTrigger value="income-expense">Income vs expenses</TabsTrigger>
+                      <TabsTrigger value="yearly">Yearly comparison</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="categories" className="mt-0">
+                      <MonthlyBreakdownChart data={report.monthlyBreakdown} />
+                    </TabsContent>
+                    <TabsContent value="trend" className="mt-0">
+                      <CategoryTrendChart data={report.categoryTrend.data} series={report.categoryTrend.series} />
+                    </TabsContent>
+                    <TabsContent value="income-expense" className="mt-0">
+                      <IncomeExpenseChart data={report.incomeExpense} />
+                    </TabsContent>
+                    <TabsContent value="yearly" className="mt-0">
+                      <YearlyComparisonChart
+                        data={report.yearlyComparison}
+                        currentLabel={currentYearLabels.current}
+                        previousLabel={currentYearLabels.previous}
+                      />
+                    </TabsContent>
+                  </Tabs>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Highlights</CardTitle>
+                  <CardDescription>Quick takeaways for this period.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {report.highlights.length > 0 ? (
+                    <ul className="space-y-3 text-sm">
+                      {report.highlights.map((highlight, index) => (
+                        <li key={`${highlight}-${index}`} className="flex items-start gap-2">
+                          <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>{highlight}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Once more transactions are categorized, you will see personalized highlights here.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Category performance</CardTitle>
+                <CardDescription>
+                  Track spending relative to your budgets and compare activity with the previous period.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Category</TableHead>
+                        <TableHead className="text-right">Spent</TableHead>
+                        <TableHead className="text-right">Budget</TableHead>
+                        <TableHead className="w-[220px]">Budget usage</TableHead>
+                        <TableHead className="text-right">Transactions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {categoryRows.length === 0 && (
+                        <TableRow>
+                          <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                            Add categorized expenses to see how you are tracking against your plans.
+                          </TableCell>
+                        </TableRow>
+                      )}
+                      {categoryRows.map(({ category, budget, spent, transactions, usagePercent, overBudget, change }) => (
+                        <TableRow key={category.id}>
+                          <TableCell>
+                            <div className="flex items-center gap-3">
+                              <span className={cn("h-2.5 w-2.5 rounded-full", category.colorClass)} />
+                              <div className="flex flex-col">
+                                <span className="font-medium">{category.name}</span>
+                                {overBudget && <Badge variant="destructive">Over budget</Badge>}
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right font-medium">{formatCurrency(spent)}</TableCell>
+                          <TableCell className="text-right text-muted-foreground">
+                            {budget > 0 ? formatCurrency(budget) : "—"}
+                          </TableCell>
+                          <TableCell>
+                            {usagePercent !== null ? (
+                              <div className="space-y-1">
+                                <Progress value={Math.min(usagePercent, 100)} />
+                                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                                  <span>{Math.round(usagePercent)}%</span>
+                                  <span className={overBudget ? "text-red-600" : "text-emerald-600"}>
+                                    {overBudget
+                                      ? `Over by ${formatCurrency(spent - budget)}`
+                                      : `Remaining ${formatCurrency(Math.max(budget - spent, 0))}`}
+                                  </span>
+                                </div>
+                              </div>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">No budget set</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="inline-flex flex-col items-end gap-1 text-sm">
+                              <span>{integerFormatter.format(transactions)}</span>
+                              {change !== null && (
+                                <span
+                                  className={cn(
+                                    "text-xs font-medium",
+                                    change > 0 ? "text-red-600" : change < 0 ? "text-emerald-600" : "text-muted-foreground",
+                                  )}
+                                >
+                                  {`${change > 0 ? "+" : ""}${change.toFixed(1)}%`}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {report.insights.length > 0 ? (
+                report.insights.map((insight, index) => {
+                  const style = INSIGHT_STYLES[insight.variant]
+                  const InsightIcon = INSIGHT_ICONS[insight.variant]
+
+                  return (
+                    <Card key={`${insight.title}-${index}`} className={cn("shadow-sm", style.container)}>
+                      <CardHeader className="space-y-2 pb-2">
+                        <div className="flex items-center gap-2 text-sm font-medium">
+                          <InsightIcon className={cn("h-4 w-4", style.icon)} />
+                          <span>{insight.title}</span>
+                        </div>
+                        <CardDescription className="text-xs leading-relaxed text-muted-foreground">
+                          {insight.description}
+                        </CardDescription>
+                      </CardHeader>
+                    </Card>
+                  )
+                })
+              ) : (
+                <Card className="md:col-span-2 xl:col-span-3">
+                  <CardContent className="py-6 text-sm text-muted-foreground">
+                    Insights will appear here once CashTrack has enough history to spot meaningful patterns.
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </AppLayout>
   )
 }
-

--- a/components/charts/category-trend-chart.tsx
+++ b/components/charts/category-trend-chart.tsx
@@ -2,16 +2,45 @@
 
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
-const data = [
-  { month: "Jul", food: 450, transport: 280, entertainment: 120, shopping: 350, bills: 725 },
-  { month: "Aug", food: 520, transport: 310, entertainment: 95, shopping: 420, bills: 750 },
-  { month: "Sep", food: 380, transport: 290, entertainment: 180, shopping: 280, bills: 725 },
-  { month: "Oct", food: 410, transport: 320, entertainment: 150, shopping: 380, bills: 780 },
-  { month: "Nov", food: 480, transport: 270, entertainment: 200, shopping: 450, bills: 725 },
-  { month: "Dec", food: 550, transport: 300, entertainment: 250, shopping: 520, bills: 800 },
+const COLOR_PALETTE = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--destructive))",
 ]
 
-export function CategoryTrendChart() {
+interface CategoryTrendChartProps {
+  data: Array<{ month: string; [key: string]: number }>
+  series: Array<{ key: string; label: string }>
+}
+
+function formatCurrency(value: number) {
+  return Number(value).toLocaleString(undefined, { style: "currency", currency: "USD" })
+}
+
+export function CategoryTrendChart({ data, series }: CategoryTrendChartProps) {
+  if (!series.length) {
+    return (
+      <div className="flex h-[350px] items-center justify-center text-sm text-muted-foreground">
+        Select categories to generate a spending trend.
+      </div>
+    )
+  }
+
+  const hasData = data.some((point) =>
+    series.some((item) => Number(point[item.key] ?? 0) !== 0),
+  )
+
+  if (!hasData) {
+    return (
+      <div className="flex h-[350px] items-center justify-center text-sm text-muted-foreground">
+        Not enough data to build a category trend yet.
+      </div>
+    )
+  }
+
   return (
     <ResponsiveContainer width="100%" height={400}>
       <LineChart data={data}>
@@ -21,7 +50,7 @@ export function CategoryTrendChart() {
           axisLine={false}
           tickLine={false}
           className="text-xs fill-muted-foreground"
-          tickFormatter={(value) => `$${value}`}
+          tickFormatter={(value) => formatCurrency(Number(value))}
         />
         <Tooltip
           content={({ active, payload, label }) => {
@@ -35,7 +64,7 @@ export function CategoryTrendChart() {
                         <span className="text-sm" style={{ color: entry.color }}>
                           {entry.name}:
                         </span>
-                        <span className="font-bold">${entry.value}</span>
+                        <span className="font-bold">{formatCurrency(Number(entry.value ?? 0))}</span>
                       </div>
                     ))}
                   </div>
@@ -46,46 +75,18 @@ export function CategoryTrendChart() {
           }}
         />
         <Legend />
-        <Line
-          type="monotone"
-          dataKey="food"
-          stroke="hsl(var(--chart-1))"
-          strokeWidth={2}
-          name="Food & Dining"
-          dot={{ r: 4 }}
-        />
-        <Line
-          type="monotone"
-          dataKey="transport"
-          stroke="hsl(var(--chart-2))"
-          strokeWidth={2}
-          name="Transportation"
-          dot={{ r: 4 }}
-        />
-        <Line
-          type="monotone"
-          dataKey="entertainment"
-          stroke="hsl(var(--chart-3))"
-          strokeWidth={2}
-          name="Entertainment"
-          dot={{ r: 4 }}
-        />
-        <Line
-          type="monotone"
-          dataKey="shopping"
-          stroke="hsl(var(--chart-4))"
-          strokeWidth={2}
-          name="Shopping"
-          dot={{ r: 4 }}
-        />
-        <Line
-          type="monotone"
-          dataKey="bills"
-          stroke="hsl(var(--chart-5))"
-          strokeWidth={2}
-          name="Bills & Utilities"
-          dot={{ r: 4 }}
-        />
+        {series.map((item, index) => (
+          <Line
+            key={item.key}
+            type="monotone"
+            dataKey={item.key}
+            stroke={COLOR_PALETTE[index % COLOR_PALETTE.length]}
+            strokeWidth={2}
+            name={item.label}
+            dot={{ r: 3 }}
+            isAnimationActive={false}
+          />
+        ))}
       </LineChart>
     </ResponsiveContainer>
   )

--- a/components/charts/monthly-breakdown-chart.tsx
+++ b/components/charts/monthly-breakdown-chart.tsx
@@ -25,10 +25,23 @@ interface MonthlyBreakdownChartProps {
 }
 
 export function MonthlyBreakdownChart({ data }: MonthlyBreakdownChartProps) {
-  const chartData = (data?.length ? data : DEFAULT_DATA).map((entry, index) => ({
+  const usingFallback = !data
+  const source = usingFallback ? DEFAULT_DATA : data
+  const chartData = source.map((entry, index) => ({
     ...entry,
     color: entry.color ?? COLOR_PALETTE[index % COLOR_PALETTE.length],
   }))
+
+  if (!usingFallback) {
+    const hasData = source.some((entry) => Number(entry.value) > 0)
+    if (!hasData) {
+      return (
+        <div className="flex h-[300px] items-center justify-center text-sm text-muted-foreground">
+          Add categorized expenses to see your spending breakdown.
+        </div>
+      )
+    }
+  }
 
   return (
     <ResponsiveContainer width="100%" height={400}>

--- a/components/charts/yearly-comparison-chart.tsx
+++ b/components/charts/yearly-comparison-chart.tsx
@@ -2,32 +2,54 @@
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
-const data = [
-  { month: "Jan", "2023": 2400, "2024": 2200 },
-  { month: "Feb", "2023": 2100, "2024": 2400 },
-  { month: "Mar", "2023": 2800, "2024": 2300 },
-  { month: "Apr", "2023": 2600, "2024": 2500 },
-  { month: "May", "2023": 2900, "2024": 2600 },
-  { month: "Jun", "2023": 3200, "2024": 2800 },
-  { month: "Jul", "2023": 2800, "2024": 2325 },
-  { month: "Aug", "2023": 3100, "2024": 2595 },
-  { month: "Sep", "2023": 2700, "2024": 2355 },
-  { month: "Oct", "2023": 2900, "2024": 2540 },
-  { month: "Nov", "2023": 3300, "2024": 2625 },
-  { month: "Dec", "2023": 3500, "2024": 2920 },
+const DEFAULT_DATA = [
+  { month: "Jan", previous: 2400, current: 2200 },
+  { month: "Feb", previous: 2100, current: 2400 },
+  { month: "Mar", previous: 2800, current: 2300 },
+  { month: "Apr", previous: 2600, current: 2500 },
+  { month: "May", previous: 2900, current: 2600 },
+  { month: "Jun", previous: 3200, current: 2800 },
+  { month: "Jul", previous: 2800, current: 2325 },
+  { month: "Aug", previous: 3100, current: 2595 },
+  { month: "Sep", previous: 2700, current: 2355 },
+  { month: "Oct", previous: 2900, current: 2540 },
+  { month: "Nov", previous: 3300, current: 2625 },
+  { month: "Dec", previous: 3500, current: 2920 },
 ]
 
-export function YearlyComparisonChart() {
+interface YearlyComparisonChartProps {
+  data?: Array<{ month: string; current: number; previous: number }>
+  currentLabel?: string
+  previousLabel?: string
+}
+
+function formatCurrency(value: number) {
+  return Number(value).toLocaleString(undefined, { style: "currency", currency: "USD" })
+}
+
+export function YearlyComparisonChart({ data, currentLabel = "Current", previousLabel = "Previous" }: YearlyComparisonChartProps) {
+  const usingFallback = !data
+  const chartData = usingFallback ? DEFAULT_DATA : data
+  const hasData = chartData.some((point) => point.current !== 0 || point.previous !== 0)
+
+  if (!usingFallback && !hasData) {
+    return (
+      <div className="flex h-[350px] items-center justify-center text-sm text-muted-foreground">
+        Year-over-year comparison becomes available once you have at least two years of spending data.
+      </div>
+    )
+  }
+
   return (
     <ResponsiveContainer width="100%" height={400}>
-      <BarChart data={data}>
+      <BarChart data={chartData}>
         <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
         <XAxis dataKey="month" axisLine={false} tickLine={false} className="text-xs fill-muted-foreground" />
         <YAxis
           axisLine={false}
           tickLine={false}
           className="text-xs fill-muted-foreground"
-          tickFormatter={(value) => `$${value}`}
+          tickFormatter={(value) => formatCurrency(Number(value))}
         />
         <Tooltip
           content={({ active, payload, label }) => {
@@ -39,9 +61,9 @@ export function YearlyComparisonChart() {
                     {payload.map((entry, index) => (
                       <div key={index} className="flex items-center justify-between gap-2">
                         <span className="text-sm" style={{ color: entry.color }}>
-                          {entry.dataKey}:
+                          {entry.name}:
                         </span>
-                        <span className="font-bold">${entry.value}</span>
+                        <span className="font-bold">{formatCurrency(Number(entry.value ?? 0))}</span>
                       </div>
                     ))}
                   </div>
@@ -52,8 +74,8 @@ export function YearlyComparisonChart() {
           }}
         />
         <Legend />
-        <Bar dataKey="2023" fill="hsl(var(--chart-1))" name="2023" radius={[4, 4, 0, 0]} />
-        <Bar dataKey="2024" fill="hsl(var(--chart-2))" name="2024" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="previous" fill="hsl(var(--chart-2))" name={previousLabel} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="current" fill="hsl(var(--chart-1))" name={currentLabel} radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/lib/activity/repository.ts
+++ b/lib/activity/repository.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from "crypto"
+import type Database from "better-sqlite3"
+
+import { getDatabase, initDatabase } from "@/lib/db"
+
+interface ActivityRow {
+  id: string
+  userId: string
+  username: string
+  action: string
+  entityType: string
+  entityId: string | null
+  details: string | null
+  createdAt: string
+}
+
+export interface ActivityRecord {
+  id: string
+  userId: string
+  username: string
+  action: string
+  entityType: string
+  entityId: string | null
+  details: Record<string, unknown> | null
+  createdAt: string
+}
+
+export interface CreateActivityInput {
+  userId: string
+  username: string
+  action: string
+  entityType: string
+  entityId?: string | null
+  details?: Record<string, unknown> | null
+  createdAt?: string
+}
+
+export interface ActivityQueryOptions {
+  userId?: string
+  actionPrefix?: string
+  limit?: number
+  since?: string
+}
+
+const databaseReady = initDatabase()
+
+async function resolveDatabase(db?: Database): Promise<Database> {
+  if (db) {
+    return db
+  }
+  await databaseReady
+  return getDatabase()
+}
+
+function mapRow(row: ActivityRow): ActivityRecord {
+  let parsedDetails: Record<string, unknown> | null = null
+
+  if (row.details) {
+    try {
+      parsedDetails = JSON.parse(row.details) as Record<string, unknown>
+    } catch {
+      parsedDetails = { raw: row.details }
+    }
+  }
+
+  return {
+    id: row.id,
+    userId: row.userId,
+    username: row.username,
+    action: row.action,
+    entityType: row.entityType,
+    entityId: row.entityId,
+    details: parsedDetails,
+    createdAt: row.createdAt,
+  }
+}
+
+function buildQuery(filters: ActivityQueryOptions = {}) {
+  const clauses: string[] = []
+  const parameters: unknown[] = []
+
+  if (filters.userId) {
+    clauses.push("userId = ?")
+    parameters.push(filters.userId)
+  }
+
+  if (filters.actionPrefix) {
+    clauses.push("action LIKE ?")
+    parameters.push(`${filters.actionPrefix.replace(/%/g, "%%")}%%`)
+  }
+
+  if (filters.since) {
+    clauses.push("createdAt >= ?")
+    parameters.push(filters.since)
+  }
+
+  return { clauses, parameters }
+}
+
+export async function recordActivity(input: CreateActivityInput, db?: Database): Promise<ActivityRecord> {
+  const connection = await resolveDatabase(db)
+  const now = input.createdAt ?? new Date().toISOString()
+  const row: ActivityRow = {
+    id: `act_${randomUUID()}`,
+    userId: input.userId,
+    username: input.username,
+    action: input.action,
+    entityType: input.entityType,
+    entityId: input.entityId ?? null,
+    details: input.details ? JSON.stringify(input.details) : null,
+    createdAt: now,
+  }
+
+  connection
+    .prepare(
+      `INSERT INTO user_activity (id, userId, username, action, entityType, entityId, details, createdAt)
+       VALUES (@id, @userId, @username, @action, @entityType, @entityId, @details, @createdAt)`
+    )
+    .run(row)
+
+  return mapRow(row)
+}
+
+export async function listRecentActivity(
+  filters: ActivityQueryOptions = {},
+): Promise<ActivityRecord[]> {
+  const connection = await resolveDatabase()
+  const { clauses, parameters } = buildQuery(filters)
+
+  let sql =
+    "SELECT id, userId, username, action, entityType, entityId, details, createdAt FROM user_activity"
+  if (clauses.length > 0) {
+    sql += ` WHERE ${clauses.join(" AND ")}`
+  }
+
+  sql += " ORDER BY datetime(createdAt) DESC"
+
+  if (typeof filters.limit === "number") {
+    sql += " LIMIT ?"
+    parameters.push(filters.limit)
+  }
+
+  const rows = connection.prepare(sql).all(...parameters) as ActivityRow[]
+  return rows.map(mapRow)
+}
+
+export async function pruneActivity(before: string): Promise<number> {
+  const connection = await resolveDatabase()
+  const statement = connection.prepare("DELETE FROM user_activity WHERE createdAt < ?")
+  const result = statement.run(before)
+  return result.changes ?? 0
+}

--- a/lib/activity/service.ts
+++ b/lib/activity/service.ts
@@ -1,0 +1,30 @@
+import type { SessionUser } from "@/lib/auth/session"
+
+import { CreateActivityInput, listRecentActivity, recordActivity } from "./repository"
+
+export async function recordUserAction(
+  user: SessionUser | undefined,
+  action: string,
+  entityType: string,
+  entityId?: string | null,
+  details?: Record<string, unknown> | null,
+) {
+  if (!user) {
+    return
+  }
+
+  const payload: CreateActivityInput = {
+    userId: user.id,
+    username: user.username,
+    action,
+    entityType,
+    entityId: entityId ?? null,
+    details: details ?? null,
+  }
+
+  await recordActivity(payload)
+}
+
+export async function getRecentActivity(limit = 20) {
+  return listRecentActivity({ limit })
+}

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -5,6 +5,7 @@ import {
   CREATE_SETTINGS_TABLE,
   CREATE_SYNC_LOG_TABLE,
   CREATE_TRANSACTIONS_TABLE,
+  CREATE_USER_ACTIVITY_TABLE,
   CREATE_USERS_TABLE,
 } from "./schema"
 
@@ -18,6 +19,8 @@ function ensureIndexes() {
     "CREATE INDEX IF NOT EXISTS idx_transactions_updatedAt ON transactions(updatedAt)",
     "CREATE INDEX IF NOT EXISTS idx_automation_rules_category_priority ON automation_rules(categoryId, priority DESC)",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_log_entity ON sync_log(entityType, entityId)",
+    "CREATE INDEX IF NOT EXISTS idx_user_activity_createdAt ON user_activity(createdAt DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_user_activity_userId ON user_activity(userId)",
   ]
 
   for (const statement of statements) {
@@ -38,6 +41,7 @@ export function runMigrations(): void {
     CREATE_AUTOMATION_RULES_TABLE,
     CREATE_SYNC_LOG_TABLE,
     CREATE_SETTINGS_TABLE,
+    CREATE_USER_ACTIVITY_TABLE,
   ]
 
   for (const statement of createStatements) {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -71,3 +71,17 @@ export const CREATE_SETTINGS_TABLE = `
     updatedAt TEXT NOT NULL
   )
 `
+
+export const CREATE_USER_ACTIVITY_TABLE = `
+  CREATE TABLE IF NOT EXISTS user_activity (
+    id TEXT PRIMARY KEY,
+    userId TEXT NOT NULL,
+    username TEXT NOT NULL,
+    action TEXT NOT NULL,
+    entityType TEXT NOT NULL,
+    entityId TEXT,
+    details TEXT,
+    createdAt TEXT NOT NULL,
+    FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+  )
+`

--- a/lib/reports/analytics.ts
+++ b/lib/reports/analytics.ts
@@ -1,0 +1,485 @@
+import { initDatabase, getDatabase } from "@/lib/db"
+import type Database from "better-sqlite3"
+
+export type ReportPeriodKey = "last-3-months" | "last-6-months" | "last-12-months" | "current-year"
+
+interface CategoryRow {
+  id: string
+  name: string
+  color: string
+  monthlyBudget: number
+}
+
+interface CategorySpendRow {
+  categoryId: string | null
+  categoryName: string
+  spent: number
+  transactions: number
+}
+
+interface CategorySpendPreviousRow {
+  categoryId: string | null
+  categoryName: string
+  spent: number
+}
+
+interface MonthlySpendRow {
+  month: string
+  income: number
+  expenses: number
+}
+
+interface CategoryMonthlySpendRow {
+  month: string
+  categoryId: string | null
+  categoryName: string
+  spent: number
+}
+
+interface YearlySpendRow {
+  month: string
+  expenses: number
+}
+
+export interface SummaryMetric {
+  label: string
+  value: number
+  change: number | null
+  direction: "up" | "down" | "flat"
+  helper?: string
+}
+
+export interface CategoryPerformance {
+  id: string
+  name: string
+  spent: number
+  budget: number
+  change: number | null
+  transactions: number
+  colorClass: string
+}
+
+export interface ChartPoint {
+  name: string
+  value: number
+  color: string
+}
+
+export interface ChartSeries {
+  key: string
+  label: string
+}
+
+export interface ReportAnalytics {
+  period: ReportPeriodKey
+  label: string
+  startDate: string
+  endDate: string
+  summary: SummaryMetric[]
+  highlights: string[]
+  categories: CategoryPerformance[]
+  monthlyBreakdown: ChartPoint[]
+  incomeExpense: Array<{ month: string; income: number; expenses: number }>
+  categoryTrend: { data: Array<{ month: string; [key: string]: number }>; series: ChartSeries[] }
+  yearlyComparison: Array<{ month: string; current: number; previous: number }>
+  insights: Array<{ variant: "positive" | "warning" | "info"; title: string; description: string }>
+}
+
+const databaseReady = initDatabase()
+
+const CHART_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+  "hsl(var(--destructive))",
+]
+
+const PERIOD_MONTHS: Record<Exclude<ReportPeriodKey, "current-year">, number> = {
+  "last-3-months": 3,
+  "last-6-months": 6,
+  "last-12-months": 12,
+}
+
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+function addMonths(date: Date, amount: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + amount, 1)
+}
+
+function formatMonthKey(date: Date): string {
+  return date.toISOString().slice(0, 7)
+}
+
+function formatMonthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map((part) => Number.parseInt(part, 10))
+  if (!Number.isFinite(year) || !Number.isFinite(month)) {
+    return monthKey
+  }
+  const date = new Date(Date.UTC(year, month - 1, 1))
+  return date.toLocaleDateString(undefined, { month: "short" })
+}
+
+function normalizeCategoryColor(color: string | null | undefined): string {
+  if (!color || typeof color !== "string") {
+    return "bg-slate-500"
+  }
+  return color
+}
+
+function calculateChange(current: number, previous: number): number | null {
+  if (previous === 0) {
+    if (current === 0) {
+      return 0
+    }
+    return null
+  }
+  return ((current - previous) / previous) * 100
+}
+
+function getCategoryKey(categoryId: string | null, categoryName: string): string {
+  return categoryId ? categoryId : `name:${categoryName.toLowerCase()}`
+}
+
+function createMonthKeys(start: Date, months: number): string[] {
+  const keys: string[] = []
+  for (let index = 0; index < months; index += 1) {
+    keys.push(formatMonthKey(addMonths(start, index)))
+  }
+  return keys
+}
+
+async function resolveDatabase(): Promise<Database> {
+  await databaseReady
+  return getDatabase()
+}
+
+export async function getReportAnalytics(period: ReportPeriodKey): Promise<ReportAnalytics> {
+  const db = await resolveDatabase()
+  const now = new Date()
+  let start = startOfMonth(now)
+  let end = addMonths(start, 1)
+  let previousStart: Date
+  let previousEnd: Date
+  let monthsInPeriod = 1
+  let label = ""
+
+  if (period === "current-year") {
+    start = new Date(now.getFullYear(), 0, 1)
+    end = new Date(now.getFullYear() + 1, 0, 1)
+    previousStart = new Date(now.getFullYear() - 1, 0, 1)
+    previousEnd = start
+    monthsInPeriod = Math.max(1, now.getMonth() + 1)
+    label = `${start.getFullYear()} Year to Date`
+  } else {
+    const months = PERIOD_MONTHS[period]
+    monthsInPeriod = months
+    start = startOfMonth(addMonths(now, -(months - 1)))
+    end = addMonths(start, months)
+    previousStart = addMonths(start, -months)
+    previousEnd = start
+    label = period.replace(/-/g, " ")
+  }
+
+  const monthKeys = createMonthKeys(start, monthsInPeriod)
+
+  const summaryRow = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS income,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
+       FROM transactions
+       WHERE date >= @start AND date < @end`,
+    )
+    .get({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as
+    | { income: number | null; expenses: number | null }
+    | undefined
+
+  const previousSummaryRow = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS income,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
+       FROM transactions
+       WHERE date >= @start AND date < @end`,
+    )
+    .get({ start: previousStart.toISOString().slice(0, 10), end: previousEnd.toISOString().slice(0, 10) }) as
+    | { income: number | null; expenses: number | null }
+    | undefined
+
+  const totalIncome = Number(summaryRow?.income ?? 0)
+  const totalExpenses = Number(summaryRow?.expenses ?? 0)
+  const previousIncome = Number(previousSummaryRow?.income ?? 0)
+  const previousExpenses = Number(previousSummaryRow?.expenses ?? 0)
+  const netSavings = totalIncome - totalExpenses
+  const previousNetSavings = previousIncome - previousExpenses
+  const savingsRate = totalIncome > 0 ? (netSavings / totalIncome) * 100 : null
+
+  const summary: SummaryMetric[] = [
+    {
+      label: "Total Income",
+      value: totalIncome,
+      change: calculateChange(totalIncome, previousIncome),
+      direction: totalIncome >= previousIncome ? "up" : "down",
+    },
+    {
+      label: "Total Expenses",
+      value: totalExpenses,
+      change: calculateChange(totalExpenses, previousExpenses),
+      direction: totalExpenses <= previousExpenses ? "down" : "up",
+    },
+    {
+      label: "Net Savings",
+      value: netSavings,
+      change: calculateChange(netSavings, previousNetSavings),
+      direction: netSavings >= previousNetSavings ? "up" : "down",
+      helper: savingsRate !== null ? `Savings rate ${savingsRate.toFixed(1)}%` : undefined,
+    },
+    {
+      label: "Avg Monthly Spending",
+      value: monthsInPeriod > 0 ? totalExpenses / monthsInPeriod : totalExpenses,
+      change: null,
+      direction: "flat",
+    },
+  ]
+
+  const categories = db
+    .prepare(
+      "SELECT id, name, color, monthlyBudget FROM categories ORDER BY name COLLATE NOCASE ASC",
+    )
+    .all() as CategoryRow[]
+
+  const categoryMap = new Map<string, CategoryRow>()
+  categories.forEach((category) => {
+    categoryMap.set(getCategoryKey(category.id, category.name), category)
+  })
+
+  const categorySpendRows = db
+    .prepare(
+      `SELECT
+         categoryId,
+         categoryName,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS spent,
+         SUM(CASE WHEN amount < 0 THEN 1 ELSE 0 END) AS transactions
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY categoryId, categoryName`,
+    )
+    .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as CategorySpendRow[]
+
+  const previousCategorySpendRows = db
+    .prepare(
+      `SELECT
+         categoryId,
+         categoryName,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS spent
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY categoryId, categoryName`,
+    )
+    .all({ start: previousStart.toISOString().slice(0, 10), end: previousEnd.toISOString().slice(0, 10) }) as CategorySpendPreviousRow[]
+
+  const previousCategoryMap = new Map<string, number>()
+  previousCategorySpendRows.forEach((row) => {
+    previousCategoryMap.set(getCategoryKey(row.categoryId, row.categoryName), Number(row.spent ?? 0))
+  })
+
+  const combinedKeys = new Set<string>()
+  categoryMap.forEach((_value, key) => combinedKeys.add(key))
+  categorySpendRows.forEach((row) => combinedKeys.add(getCategoryKey(row.categoryId, row.categoryName)))
+
+  const categoryPerformances: CategoryPerformance[] = []
+  combinedKeys.forEach((key) => {
+    const base = categoryMap.get(key)
+    const spendRow = categorySpendRows.find((row) => getCategoryKey(row.categoryId, row.categoryName) === key)
+    const previousSpent = previousCategoryMap.get(key) ?? 0
+    const name = base?.name ?? spendRow?.categoryName ?? "Uncategorized"
+    const spent = Number(spendRow?.spent ?? 0)
+    const transactions = Number(spendRow?.transactions ?? 0)
+    const monthlyBudget = Number(base?.monthlyBudget ?? 0)
+    const budget = monthlyBudget * (monthsInPeriod > 0 ? monthsInPeriod : 1)
+    const colorClass = normalizeCategoryColor(base?.color)
+    const change = calculateChange(spent, previousSpent)
+
+    categoryPerformances.push({
+      id: base?.id ?? key,
+      name,
+      spent,
+      budget,
+      change,
+      transactions,
+      colorClass,
+    })
+  })
+
+  categoryPerformances.sort((a, b) => b.spent - a.spent)
+
+  const highlights: string[] = []
+  const topCategory = categoryPerformances[0]
+  if (topCategory) {
+    highlights.push(`${topCategory.name} is your largest category at $${topCategory.spent.toFixed(2)}`)
+  }
+  if (savingsRate !== null) {
+    highlights.push(`Savings rate: ${savingsRate.toFixed(1)}%`)
+  }
+  const totalTransactionsRow = db
+    .prepare("SELECT COUNT(*) as count FROM transactions WHERE date >= ? AND date < ?")
+    .get(start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)) as { count: number } | undefined
+  highlights.push(`Logged ${Number(totalTransactionsRow?.count ?? 0)} transactions this period`)
+
+  const monthlyRows = db
+    .prepare(
+      `SELECT
+         SUBSTR(date, 1, 7) AS month,
+         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS income,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY SUBSTR(date, 1, 7)`
+    )
+    .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as MonthlySpendRow[]
+
+  const monthlyMap = new Map<string, { income: number; expenses: number }>()
+  monthlyRows.forEach((row) => {
+    if (row.month) {
+      monthlyMap.set(row.month, { income: Number(row.income ?? 0), expenses: Number(row.expenses ?? 0) })
+    }
+  })
+
+  const incomeExpense = monthKeys.map((key) => {
+    const entry = monthlyMap.get(key) ?? { income: 0, expenses: 0 }
+    return { month: formatMonthLabel(key), income: entry.income, expenses: entry.expenses }
+  })
+
+  const categoryMonthlyRows = db
+    .prepare(
+      `SELECT
+         SUBSTR(date, 1, 7) AS month,
+         categoryId,
+         categoryName,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS spent
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY SUBSTR(date, 1, 7), categoryId, categoryName`
+    )
+    .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as CategoryMonthlySpendRow[]
+
+  const trendSeries: ChartSeries[] = categoryPerformances.slice(0, 5).map((category) => ({
+    key: getCategoryKey(category.id === category.name ? null : category.id, category.name),
+    label: category.name,
+  }))
+
+  const trendData = monthKeys.map((key) => {
+    const row: Record<string, number | string> = { month: formatMonthLabel(key) }
+    trendSeries.forEach((series) => {
+      const match = categoryMonthlyRows.find(
+        (entry) => entry.month === key && getCategoryKey(entry.categoryId, entry.categoryName) === series.key,
+      )
+      row[series.key] = Number(match?.spent ?? 0)
+    })
+    return row as { month: string; [key: string]: number }
+  })
+
+  const monthlyBreakdown = categoryPerformances
+    .filter((category) => category.spent > 0)
+    .slice(0, CHART_COLORS.length)
+    .map((category, index) => ({ name: category.name, value: category.spent, color: CHART_COLORS[index % CHART_COLORS.length] }))
+
+  const currentYearStart = new Date(start.getFullYear(), 0, 1)
+  const nextYearStart = new Date(start.getFullYear() + 1, 0, 1)
+  const previousYearStart = new Date(start.getFullYear() - 1, 0, 1)
+
+  const currentYearRows = db
+    .prepare(
+      `SELECT SUBSTR(date, 1, 7) AS month, SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY SUBSTR(date, 1, 7)`
+    )
+    .all({ start: currentYearStart.toISOString().slice(0, 10), end: nextYearStart.toISOString().slice(0, 10) }) as YearlySpendRow[]
+
+  const previousYearRows = db
+    .prepare(
+      `SELECT SUBSTR(date, 1, 7) AS month, SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
+       FROM transactions
+       WHERE date >= @start AND date < @end
+       GROUP BY SUBSTR(date, 1, 7)`
+    )
+    .all({ start: previousYearStart.toISOString().slice(0, 10), end: currentYearStart.toISOString().slice(0, 10) }) as YearlySpendRow[]
+
+  const currentYearMap = new Map<string, number>()
+  currentYearRows.forEach((row) => {
+    if (row.month) {
+      currentYearMap.set(row.month, Number(row.expenses ?? 0))
+    }
+  })
+
+  const previousYearMap = new Map<string, number>()
+  previousYearRows.forEach((row) => {
+    if (row.month) {
+      previousYearMap.set(row.month, Number(row.expenses ?? 0))
+    }
+  })
+
+  const yearlyComparison: Array<{ month: string; current: number; previous: number }> = []
+  for (let monthIndex = 0; monthIndex < 12; monthIndex += 1) {
+    const monthDate = new Date(Date.UTC(start.getFullYear(), monthIndex, 1))
+    const key = formatMonthKey(monthDate)
+    yearlyComparison.push({
+      month: monthDate.toLocaleDateString(undefined, { month: "short" }),
+      current: currentYearMap.get(key) ?? 0,
+      previous:
+        previousYearMap.get(`${start.getFullYear() - 1}-${String(monthIndex + 1).padStart(2, "0")}`) ?? 0,
+    })
+  }
+
+  const overBudget = categoryPerformances.filter((category) => category.budget > 0 && category.spent > category.budget)
+
+  const insights: Array<{ variant: "positive" | "warning" | "info"; title: string; description: string }> = []
+  if (savingsRate !== null) {
+    insights.push({
+      variant: savingsRate >= 0 ? "positive" : "warning",
+      title: savingsRate >= 0 ? "You saved money" : "Spending exceeded income",
+      description:
+        savingsRate >= 0
+          ? `Saved ${savingsRate.toFixed(1)}% of income during this period.`
+          : `Spending outpaced income by ${Math.abs(savingsRate).toFixed(1)}%. Review discretionary purchases.`,
+    })
+  }
+
+  if (overBudget.length > 0) {
+    const topOver = overBudget[0]
+    const overPercent = topOver.budget > 0 ? ((topOver.spent - topOver.budget) / topOver.budget) * 100 : 0
+    insights.push({
+      variant: "warning",
+      title: `${topOver.name} exceeded budget`,
+      description: `Spent ${overPercent.toFixed(1)}% over the planned $${topOver.budget.toFixed(2)} budget.`,
+    })
+  }
+
+  if (topCategory) {
+    insights.push({
+      variant: "info",
+      title: `${topCategory.name} dominates spending`,
+      description: `${topCategory.transactions} transactions totaled $${topCategory.spent.toFixed(2)} in this category.`,
+    })
+  }
+
+  return {
+    period,
+    label,
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+    summary,
+    highlights,
+    categories: categoryPerformances,
+    monthlyBreakdown,
+    incomeExpense,
+    categoryTrend: { data: trendData, series: trendSeries },
+    yearlyComparison,
+    insights,
+  }
+}

--- a/lib/transactions/analytics.ts
+++ b/lib/transactions/analytics.ts
@@ -235,7 +235,6 @@ export async function getDashboardAnalytics(): Promise<DashboardAnalytics> {
       }
       return b.spent - a.spent
     })
-    .slice(0, 4)
 
   const budgetWarningCandidate = budgetOverview
     .filter((entry) => entry.budget > 0)

--- a/lib/transactions/pdf-parser.ts
+++ b/lib/transactions/pdf-parser.ts
@@ -1,0 +1,196 @@
+import pdfParse from "pdf-parse"
+
+import type { ParsedCsvTransaction, TransactionType } from "@/lib/transactions/types"
+
+function normalizePdfDate(value: string): string | null {
+  const trimmed = value.trim().replace(/\s+/g, " ")
+  if (!trimmed) return null
+
+  const direct = new Date(trimmed)
+  if (!Number.isNaN(direct.getTime())) {
+    return direct.toISOString().slice(0, 10)
+  }
+
+  const monthNameMatch = trimmed.match(/^(\d{1,2})\s+([A-Za-z]{3,})\s+(\d{2,4})$/)
+  if (monthNameMatch) {
+    const day = Number.parseInt(monthNameMatch[1], 10)
+    const monthName = monthNameMatch[2]
+    const yearRaw = Number.parseInt(monthNameMatch[3], 10)
+    if (!Number.isFinite(day) || !Number.isFinite(yearRaw)) {
+      return null
+    }
+    const year = yearRaw < 100 ? (yearRaw >= 70 ? 1900 + yearRaw : 2000 + yearRaw) : yearRaw
+    const parsed = new Date(`${monthName} ${day}, ${year}`)
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().slice(0, 10)
+    }
+  }
+
+  const swapped = trimmed.replace(/[.\-]/g, "/")
+  const parts = swapped.split("/")
+  if (parts.length === 3) {
+    let [part1, part2, part3] = parts.map((part) => part.trim())
+    if (!part1 || !part2 || !part3) {
+      return null
+    }
+
+    let year = Number.parseInt(part3, 10)
+    let month = Number.parseInt(part1, 10)
+    let day = Number.parseInt(part2, 10)
+
+    if (part1.length === 4) {
+      year = Number.parseInt(part1, 10)
+      month = Number.parseInt(part2, 10)
+      day = Number.parseInt(part3, 10)
+    } else if (part3.length !== 4) {
+      year = Number.parseInt(part3, 10)
+    }
+
+    if (part3.length === 2) {
+      year = year >= 70 ? 1900 + year : 2000 + year
+    }
+
+    if (month > 12 && day <= 12) {
+      const temp = month
+      month = day
+      day = temp
+    }
+
+    if (day > 31 && month <= 12) {
+      const temp = day
+      day = month
+      month = temp
+    }
+
+    if (Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(day)) {
+      const parsed = new Date(Date.UTC(year, month - 1, day))
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed.toISOString().slice(0, 10)
+      }
+    }
+  }
+
+  return null
+}
+
+function sanitizeAmount(value: string): number {
+  const trimmed = value.trim()
+  let negative = false
+
+  if (trimmed.includes("(") && trimmed.includes(")")) {
+    negative = true
+  }
+
+  if (/DR$/i.test(trimmed)) {
+    negative = true
+  }
+
+  if (/CR$/i.test(trimmed)) {
+    negative = false
+  }
+
+  if (trimmed.endsWith("-")) {
+    negative = true
+  }
+
+  let cleaned = trimmed.replace(/(CR|cr|DR|dr)$/g, "")
+  cleaned = cleaned.replace(/[^0-9.,()\-]/g, "")
+  if (cleaned.endsWith("-")) {
+    negative = true
+    cleaned = cleaned.slice(0, -1)
+  }
+  cleaned = cleaned.replace(/[,$]/g, "").replace(/[()]/g, "")
+
+  const amount = Number(cleaned)
+  if (Number.isNaN(amount)) {
+    throw new Error(`Invalid amount: ${value}`)
+  }
+
+  return negative ? -Math.abs(amount) : amount
+}
+
+function resolveTransactionAmount(amounts: number[]): number {
+  if (amounts.length === 0) {
+    throw new Error("Missing amount")
+  }
+
+  if (amounts.length >= 3) {
+    const debit = amounts[0]
+    const credit = amounts[1]
+    if (Math.abs(credit) > 0) {
+      return credit
+    }
+    if (Math.abs(debit) > 0) {
+      return -Math.abs(debit)
+    }
+  }
+
+  if (amounts.length >= 2) {
+    const [first] = amounts
+    if (Math.abs(first) > 0) {
+      return first
+    }
+  }
+
+  return amounts[0]
+}
+
+export async function parsePdfTransactions(
+  buffer: Buffer,
+  options: { accountName?: string } = {},
+): Promise<{ transactions: ParsedCsvTransaction[]; errors: Array<{ line: number; message: string }> }> {
+  const result = await pdfParse(buffer)
+  const lines = result.text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+
+  const transactions: ParsedCsvTransaction[] = []
+  const errors: Array<{ line: number; message: string }> = []
+  const account = options.accountName?.trim() || "Statement"
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1
+    const match = line.match(
+      /^(\d{1,2}[\/-]\d{1,2}[\/-]\d{2,4}|\d{4}[\/-]\d{1,2}[\/-]\d{1,2}|\d{1,2}\s+[A-Za-z]{3,}\s+\d{2,4})\s+(.*)$/,
+    )
+    if (!match) {
+      return
+    }
+
+    const dateValue = normalizePdfDate(match[1])
+    if (!dateValue) {
+      errors.push({ line: lineNumber, message: `Unrecognized date: ${match[1]}` })
+      return
+    }
+
+    const remainder = match[2].trim()
+    const amountMatches = Array.from(remainder.matchAll(/-?\$?\(?\d{1,3}(?:,\d{3})*(?:\.\d{2})?\)?(?:CR|DR)?/g))
+    if (amountMatches.length === 0) {
+      errors.push({ line: lineNumber, message: "Unable to locate amount" })
+      return
+    }
+
+    const firstAmount = amountMatches[0]
+    const descriptionRaw = remainder.slice(0, firstAmount.index).trim()
+    const description = descriptionRaw || "Statement entry"
+
+    try {
+      const amountValues = amountMatches.map((matchResult) => sanitizeAmount(matchResult[0]))
+      const resolvedAmount = resolveTransactionAmount(amountValues)
+      const type: TransactionType = resolvedAmount >= 0 ? "income" : "expense"
+
+      transactions.push({
+        date: dateValue,
+        description,
+        amount: Math.abs(resolvedAmount),
+        type,
+        account,
+      })
+    } catch (error) {
+      errors.push({ line: lineNumber, message: (error as Error).message })
+    }
+  })
+
+  return { transactions, errors }
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lucide-react": "^0.454.0",
     "next": "^14.2.32",
     "next-themes": "latest",
+    "pdf-parse": "^1.1.1",
     "react": "^18",
     "react-day-picker": "9.8.0",
     "react-dom": "^18",
@@ -79,8 +80,8 @@
     "eslint-config-next": "15.5.3",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
-    "tw-animate-css": "1.3.3",
     "tsx": "^4.19.2",
+    "tw-animate-css": "1.3.3",
     "typescript": "^5"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.1
       react:
         specifier: ^18
         version: 18.3.1
@@ -2583,6 +2586,9 @@ packages:
     resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
     engines: {node: '>=10'}
 
+  node-ensure@0.0.0:
+    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
@@ -2666,6 +2672,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pdf-parse@1.1.1:
+    resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
+    engines: {node: '>=6.8.1'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5663,6 +5673,8 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
+  node-ensure@0.0.0: {}
+
   node-releases@2.0.21: {}
 
   node-windows@0.1.14:
@@ -5759,6 +5771,13 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pdf-parse@1.1.1:
+    dependencies:
+      debug: 3.2.7
+      node-ensure: 0.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## Summary
- add household account management endpoints and activity log service so the shared account can audit actions
- extend transaction import to parse PDF bank statements and surface the flow in the UI
- implement reporting analytics with a new API plus dynamic charts fed by live category, trend, and income/expense data

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d101113ecc83279642c19d3ca35cb1