### PR TITLE
Enable PDF reporting, account management, and transfers

### DIFF
--- a/app/api/accounts/[id]/route.ts
+++ b/app/api/accounts/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { updateAccount, deleteAccount } from "@/lib/accounts/service"
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { recordUserAction } from "@/lib/activity/service"
+
+const updateSchema = z.object({
+  name: z.string().min(1, "Account name is required").max(120),
+})
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await requireSession()
+    const payload = await request.json()
+    const parsed = updateSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const account = await updateAccount(params.id, { name: parsed.data.name })
+    await recordUserAction(session.user, "account.update", "account", account.id, { account: account.name })
+    return NextResponse.json({ account })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+
+    const message = error instanceof Error ? error.message : "Unable to update account"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await requireSession()
+    await deleteAccount(params.id)
+    await recordUserAction(session.user, "account.delete", "account", params.id)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+
+    const message = error instanceof Error ? error.message : "Unable to delete account"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/accounts/route.ts
+++ b/app/api/accounts/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { listAccountsWithBalances, createAccount } from "@/lib/accounts/service"
+import { recordUserAction } from "@/lib/activity/service"
+
+const createSchema = z.object({
+  name: z.string().min(1, "Account name is required").max(120),
+})
+
+export async function GET() {
+  try {
+    await requireSession()
+    const accounts = await listAccountsWithBalances()
+    return NextResponse.json({ accounts })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireSession()
+    const payload = await request.json()
+    const parsed = createSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const account = await createAccount({ name: parsed.data.name })
+    await recordUserAction(session.user, "account.create", "account", account.id, { account: account.name })
+    return NextResponse.json({ account }, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+
+    const message = error instanceof Error ? error.message : "Unable to create account"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/reports/pdf/route.ts
+++ b/app/api/reports/pdf/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { getReportAnalytics, type ReportPeriodKey } from "@/lib/reports/analytics"
+import { buildReportPdf } from "@/lib/reports/pdf"
+
+const querySchema = z.object({
+  period: z.enum(["last-3-months", "last-6-months", "last-12-months", "current-year"]).optional(),
+})
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireSession()
+    const url = new URL(request.url)
+    const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams.entries()))
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const period: ReportPeriodKey = parsed.data.period ?? "last-3-months"
+    const report = await getReportAnalytics(period)
+    const pdfBytes = await buildReportPdf(report)
+    const fileName = `cashtrack-report-${period}.pdf`
+
+    return new NextResponse(Buffer.from(pdfBytes), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${fileName}"`,
+        "Cache-Control": "no-store",
+      },
+    })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -12,7 +12,7 @@ const querySchema = z.object({
   categoryName: z.string().optional(),
   status: z.enum(["pending", "completed", "cleared"]).optional(),
   account: z.string().optional(),
-  type: z.enum(["income", "expense"]).optional(),
+  type: z.enum(["income", "expense", "transfer"]).optional(),
   startDate: z
     .string()
     .optional()

--- a/app/api/transactions/transfers/route.ts
+++ b/app/api/transactions/transfers/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+
+import { createTransfer } from "@/lib/transactions/service"
+import { AuthenticationError, PasswordChangeRequiredError, requireSession } from "@/lib/auth/session"
+import { recordUserAction } from "@/lib/activity/service"
+
+const createTransferSchema = z.object({
+  date: z.string().min(1, "Date is required"),
+  description: z.string().optional(),
+  amount: z.coerce.number().gt(0, "Amount must be greater than zero"),
+  fromAccount: z.string().min(1, "From account is required"),
+  toAccount: z.string().min(1, "To account is required"),
+  status: z.enum(["pending", "completed", "cleared"]).default("completed"),
+  notes: z.string().optional(),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await requireSession()
+    const payload = await request.json()
+    const parsed = createTransferSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const { transferId, transactions } = await createTransfer({
+      date: parsed.data.date,
+      description: parsed.data.description ?? "",
+      amount: parsed.data.amount,
+      fromAccount: parsed.data.fromAccount,
+      toAccount: parsed.data.toAccount,
+      status: parsed.data.status,
+      notes: parsed.data.notes,
+    })
+
+    await recordUserAction(session.user, "transaction.transfer", "transaction", transferId, {
+      amount: parsed.data.amount,
+      fromAccount: parsed.data.fromAccount,
+      toAccount: parsed.data.toAccount,
+    })
+
+    return NextResponse.json({ transferId, transactions }, { status: 201 })
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return NextResponse.json({ error: error.message }, { status: 401 })
+    }
+    if (error instanceof PasswordChangeRequiredError) {
+      return NextResponse.json({ error: error.message }, { status: 403 })
+    }
+
+    const message = error instanceof Error ? error.message : "Unable to create transfer"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -8,9 +8,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Upload, Search, Filter, Plus, Edit, Trash2, ArrowUpDown, Loader2 } from "lucide-react"
+import { Upload, Search, Filter, Plus, Edit, Trash2, ArrowUpDown, Loader2, ArrowLeftRight, Settings } from "lucide-react"
 import { TransactionImportDialog } from "@/components/transaction-import-dialog"
 import { TransactionFormDialog, type TransactionFormValues } from "@/components/transaction-form-dialog"
+import { TransferDialog, type TransferFormValues } from "@/components/transfer-dialog"
+import { AccountManagerDialog } from "@/components/account-manager-dialog"
 import type { TransactionStatus, TransactionType } from "@/lib/transactions/types"
 import { toast } from "sonner"
 import { useTranslations } from "@/components/language-provider"
@@ -26,6 +28,8 @@ interface Transaction {
   status: TransactionStatus
   type: TransactionType
   notes?: string | null
+  transferGroupId?: string | null
+  transferDirection?: "in" | "out" | null
 }
 
 interface TransactionsResponse {
@@ -46,6 +50,20 @@ interface CategoryOption {
   color: string
 }
 
+interface AccountOption {
+  id: string
+  name: string
+}
+
+interface AccountSummary {
+  id: string
+  name: string
+  balance: number
+  inflow: number
+  outflow: number
+  transactions: number
+}
+
 const DEFAULT_CATEGORY_FILTER = "all"
 
 export default function TransactionsPage() {
@@ -64,6 +82,10 @@ export default function TransactionsPage() {
   const [formMode, setFormMode] = useState<"create" | "edit">("create")
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null)
   const [categories, setCategories] = useState<CategoryOption[]>([])
+  const [accounts, setAccounts] = useState<AccountOption[]>([])
+  const [accountSummaries, setAccountSummaries] = useState<AccountSummary[]>([])
+  const [isTransferOpen, setIsTransferOpen] = useState(false)
+  const [isManageAccountsOpen, setIsManageAccountsOpen] = useState(false)
   const statusLabels = useMemo(
     () => ({
       pending: t("Pending"),
@@ -71,6 +93,19 @@ export default function TransactionsPage() {
       completed: t("Completed"),
     }),
     [t],
+  )
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+      }),
+    [],
+  )
+  const totalBalance = useMemo(
+    () => accountSummaries.reduce((sum, account) => sum + account.balance, 0),
+    [accountSummaries],
   )
 
   const loadCategories = useCallback(async () => {
@@ -88,6 +123,44 @@ export default function TransactionsPage() {
     } catch (loadError) {
       console.error(loadError)
       toast.error(t("Unable to load categories"), {
+        description: loadError instanceof Error ? loadError.message : undefined,
+      })
+    }
+  }, [t])
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      const response = await fetch("/api/accounts", { cache: "no-store" })
+      if (!response.ok) {
+        throw new Error(t("Failed to load accounts"))
+      }
+
+      const data = (await response.json()) as {
+        accounts: Array<{
+          id: string
+          name: string
+          balance?: number
+          inflow?: number
+          outflow?: number
+          transactions?: number
+        }>
+      }
+
+      const summaries = data.accounts.map((account) => ({
+        id: account.id,
+        name: account.name,
+        balance: Number(account.balance ?? 0),
+        inflow: Number(account.inflow ?? 0),
+        outflow: Number(account.outflow ?? 0),
+        transactions: Number(account.transactions ?? 0),
+      }))
+
+      summaries.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
+      setAccountSummaries(summaries)
+      setAccounts(summaries.map(({ id, name }) => ({ id, name })))
+    } catch (loadError) {
+      console.error(loadError)
+      toast.error(t("Unable to load accounts"), {
         description: loadError instanceof Error ? loadError.message : undefined,
       })
     }
@@ -132,7 +205,8 @@ export default function TransactionsPage() {
 
   useEffect(() => {
     loadCategories()
-  }, [loadCategories])
+    loadAccounts()
+  }, [loadCategories, loadAccounts])
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -158,6 +232,10 @@ export default function TransactionsPage() {
   }
 
   const openEditDialog = (transaction: Transaction) => {
+    if (transaction.type === "transfer") {
+      toast.info(t("Transfers cannot be edited. Delete and recreate the transfer instead."))
+      return
+    }
     setFormMode("edit")
     setSelectedTransaction(transaction)
     setIsFormOpen(true)
@@ -212,10 +290,121 @@ export default function TransactionsPage() {
     }
 
     await fetchTransactions()
+    await loadAccounts()
   }
 
+  const handleCreateAccount = useCallback(
+    async (name: string) => {
+      const response = await fetch("/api/accounts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      })
+
+      const body = (await response.json().catch(() => ({}))) as {
+        account?: { id: string; name: string }
+        error?: unknown
+      }
+
+      if (!response.ok || !body.account) {
+        const message = typeof body.error === "string" ? body.error : t("Unable to create account")
+        toast.error(t("Unable to create account"), { description: message })
+        throw new Error(message)
+      }
+
+      const account = { id: body.account.id, name: body.account.name }
+      toast.success(t("Account created"), { description: account.name })
+      await loadAccounts()
+      return account
+    },
+    [loadAccounts, t],
+  )
+
+  const handleTransferSubmit = async (values: TransferFormValues) => {
+    const amount = Number(values.amount)
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error(t("Amount must be greater than zero"))
+    }
+
+    const payload = {
+      date: values.date,
+      description: values.description,
+      amount,
+      fromAccount: values.fromAccount,
+      toAccount: values.toAccount,
+      status: values.status,
+      ...(values.notes ? { notes: values.notes } : {}),
+    }
+
+    const response = await fetch("/api/transactions/transfers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+
+    const body = (await response.json().catch(() => ({}))) as {
+      transferId?: string
+      error?: unknown
+    }
+
+    if (!response.ok || !body.transferId) {
+      const message = typeof body.error === "string" ? body.error : t("Unable to create transfer")
+      throw new Error(message)
+    }
+
+    toast.success(t("Transfer created"))
+    await fetchTransactions()
+    await loadAccounts()
+  }
+
+  const handleRenameAccount = useCallback(
+    async (id: string, name: string) => {
+      const response = await fetch(`/api/accounts/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      })
+
+      const body = (await response.json().catch(() => ({}))) as {
+        account?: { id: string; name: string }
+        error?: unknown
+      }
+
+      if (!response.ok || !body.account) {
+        const message = typeof body.error === "string" ? body.error : t("Unable to update account")
+        throw new Error(message)
+      }
+
+      toast.success(t("Account renamed"), { description: body.account.name })
+      await fetchTransactions()
+      await loadAccounts()
+    },
+    [fetchTransactions, loadAccounts, t],
+  )
+
+  const handleDeleteAccount = useCallback(
+    async (id: string) => {
+      const response = await fetch(`/api/accounts/${id}`, { method: "DELETE" })
+      const body = (await response.json().catch(() => ({}))) as { error?: unknown }
+
+      if (!response.ok) {
+        const message = typeof body.error === "string" ? body.error : t("Unable to delete account")
+        throw new Error(message)
+      }
+
+      toast.success(t("Account deleted"))
+      await fetchTransactions()
+      await loadAccounts()
+    },
+    [fetchTransactions, loadAccounts, t],
+  )
+
   const handleDelete = async (transaction: Transaction) => {
-    const confirmed = window.confirm(t("Delete this transaction?"))
+    const confirmed = window.confirm(
+      transaction.type === "transfer"
+        ? t("Delete this transfer? Both linked entries will be removed.")
+        : t("Delete this transaction?"),
+    )
     if (!confirmed) return
 
     try {
@@ -231,6 +420,7 @@ export default function TransactionsPage() {
 
       toast.success(t("Transaction deleted"))
       await fetchTransactions()
+      await loadAccounts()
     } catch (deleteError) {
       const message = deleteError instanceof Error ? deleteError.message : t("Unable to delete transaction")
       toast.error(t("Delete failed"), { description: message })
@@ -244,10 +434,11 @@ export default function TransactionsPage() {
       toast.info(t("No new transactions imported"))
     }
     fetchTransactions()
+    loadAccounts()
   }
 
   const selectedTransactionValues = useMemo(() => {
-    if (!selectedTransaction) return undefined
+    if (!selectedTransaction || selectedTransaction.type === "transfer") return undefined
     return {
       date: selectedTransaction.date,
       description: selectedTransaction.description,
@@ -295,41 +486,78 @@ export default function TransactionsPage() {
       )
     }
 
-    return transactions.map((transaction) => (
-      <TableRow key={transaction.id}>
-        <TableCell className="font-medium">{new Date(transaction.date).toLocaleDateString()}</TableCell>
-        <TableCell>
-          <div className="max-w-[300px]">
-            <p className="truncate font-medium">{transaction.description}</p>
-            {transaction.notes && <p className="truncate text-xs text-muted-foreground">{transaction.notes}</p>}
-          </div>
-        </TableCell>
-        <TableCell>
-          <Badge variant="secondary">{transaction.categoryName || t("Uncategorized")}</Badge>
-        </TableCell>
-        <TableCell className="text-muted-foreground">{transaction.account}</TableCell>
-        <TableCell>
-          <span className={`font-medium ${transaction.amount > 0 ? "text-green-600" : "text-red-600"}`}>
-            {transaction.amount > 0 ? "+" : "-"}${Math.abs(transaction.amount).toFixed(2)}
-          </span>
-        </TableCell>
-        <TableCell>
-          <Badge variant={transaction.status === "completed" ? "default" : "secondary"}>
-            {statusLabels[transaction.status] ?? transaction.status}
-          </Badge>
-        </TableCell>
-        <TableCell className="text-right">
-          <div className="flex justify-end gap-2">
-            <Button variant="ghost" size="sm" onClick={() => openEditDialog(transaction)}>
-              <Edit className="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => handleDelete(transaction)}>
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
-        </TableCell>
-      </TableRow>
-    ))
+    return transactions.map((transaction) => {
+      const isTransfer = transaction.type === "transfer"
+      const isInboundTransfer = isTransfer && (transaction.transferDirection === "in" || transaction.amount > 0)
+      const amountValue = Math.abs(transaction.amount)
+      const formattedAmount = currencyFormatter.format(amountValue)
+      const amountClass = isTransfer
+        ? isInboundTransfer
+          ? "text-sky-600"
+          : "text-amber-600"
+        : transaction.amount > 0
+        ? "text-green-600"
+        : "text-red-600"
+      const amountPrefix = isTransfer
+        ? isInboundTransfer
+          ? "+"
+          : "-"
+        : transaction.amount > 0
+        ? "+"
+        : "-"
+
+      return (
+        <TableRow key={transaction.id}>
+          <TableCell className="font-medium">{new Date(transaction.date).toLocaleDateString()}</TableCell>
+          <TableCell>
+            <div className="max-w-[300px] space-y-1">
+              <p className="truncate font-medium">{transaction.description}</p>
+              {isTransfer && (
+                <Badge variant="outline" className="w-max text-xs">
+                  {isInboundTransfer ? t("Transfer in") : t("Transfer out")}
+                </Badge>
+              )}
+              {transaction.notes && <p className="truncate text-xs text-muted-foreground">{transaction.notes}</p>}
+            </div>
+          </TableCell>
+          <TableCell>
+            {isTransfer ? (
+              <Badge variant="outline">{t("Transfer")}</Badge>
+            ) : (
+              <Badge variant="secondary">{transaction.categoryName || t("Uncategorized")}</Badge>
+            )}
+          </TableCell>
+          <TableCell className="text-muted-foreground">{transaction.account}</TableCell>
+          <TableCell>
+            <span className={`font-medium ${amountClass}`}>
+              {amountPrefix}
+              {formattedAmount}
+            </span>
+          </TableCell>
+          <TableCell>
+            <Badge variant={transaction.status === "completed" ? "default" : "secondary"}>
+              {statusLabels[transaction.status] ?? transaction.status}
+            </Badge>
+          </TableCell>
+          <TableCell className="text-right">
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => openEditDialog(transaction)}
+                disabled={isTransfer}
+                title={isTransfer ? t("Transfers cannot be edited") : undefined}
+              >
+                <Edit className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleDelete(transaction)}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </TableCell>
+        </TableRow>
+      )
+    })
   }
 
   return (
@@ -337,7 +565,15 @@ export default function TransactionsPage() {
       title={t("Transactions")}
       description={t("Manage and track your financial transactions")}
       action={
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" onClick={() => setIsManageAccountsOpen(true)}>
+            <Settings className="mr-2 h-4 w-4" />
+            {t("Manage Accounts")}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setIsTransferOpen(true)}>
+            <ArrowLeftRight className="mr-2 h-4 w-4" />
+            {t("Transfer")}
+          </Button>
           <Button variant="outline" size="sm" onClick={() => setIsImportOpen(true)}>
             <Upload className="mr-2 h-4 w-4" />
             {t("Import CSV")}
@@ -350,6 +586,66 @@ export default function TransactionsPage() {
       }
     >
       <div className="space-y-6">
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle>{t("Accounts overview")}</CardTitle>
+              <CardDescription>{t("Monitor balances across your accounts")}</CardDescription>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="text-right">
+                <p className="text-xs text-muted-foreground">{t("Total balance")}</p>
+                <p className={`text-lg font-semibold ${totalBalance >= 0 ? "text-green-600" : "text-red-600"}`}>
+                  {currencyFormatter.format(totalBalance)}
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => setIsManageAccountsOpen(true)}>
+                <Settings className="mr-2 h-4 w-4" />
+                {t("Manage")}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {accountSummaries.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {t("No accounts yet. Create one when logging a transaction or transfer.")}
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {accountSummaries.map((account) => (
+                  <div key={account.id} className="rounded-md border p-4">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="font-medium">{account.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {t("Transactions: {{count}}", { values: { count: account.transactions.toString() } })}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-4 text-sm">
+                        <span className="text-green-600">
+                          {t("In: {{value}}", { values: { value: currencyFormatter.format(account.inflow) } })}
+                        </span>
+                        <span className="text-red-600">
+                          {t("Out: {{value}}", { values: { value: currencyFormatter.format(account.outflow) } })}
+                        </span>
+                        <span
+                          className={
+                            account.balance >= 0
+                              ? "font-semibold text-green-600"
+                              : "font-semibold text-red-600"
+                          }
+                        >
+                          {t("Balance: {{value}}", { values: { value: currencyFormatter.format(account.balance) } })}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
         <Card>
           <CardHeader>
             <CardTitle>{t("Filter Transactions")}</CardTitle>
@@ -450,6 +746,25 @@ export default function TransactionsPage() {
         onSubmit={handleFormSubmit}
         initialValues={selectedTransactionValues}
         categories={categories.map(({ id, name }) => ({ id, name }))}
+        accounts={accounts}
+        onCreateAccount={handleCreateAccount}
+      />
+      <TransferDialog
+        open={isTransferOpen}
+        onOpenChange={setIsTransferOpen}
+        accounts={accounts}
+        onSubmit={handleTransferSubmit}
+        onCreateAccount={handleCreateAccount}
+      />
+      <AccountManagerDialog
+        open={isManageAccountsOpen}
+        onOpenChange={setIsManageAccountsOpen}
+        accounts={accountSummaries}
+        onCreate={async (name) => {
+          await handleCreateAccount(name)
+        }}
+        onRename={handleRenameAccount}
+        onDelete={handleDeleteAccount}
       />
     </AppLayout>
   )

--- a/components/account-manager-dialog.tsx
+++ b/components/account-manager-dialog.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
+import { useTranslations } from "@/components/language-provider"
+
+interface ManagedAccount {
+  id: string
+  name: string
+  balance: number
+  inflow: number
+  outflow: number
+  transactions: number
+}
+
+interface AccountManagerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accounts: ManagedAccount[]
+  onCreate: (name: string) => Promise<void>
+  onRename: (id: string, name: string) => Promise<void>
+  onDelete: (id: string) => Promise<void>
+}
+
+export function AccountManagerDialog({
+  open,
+  onOpenChange,
+  accounts,
+  onCreate,
+  onRename,
+  onDelete,
+}: AccountManagerDialogProps) {
+  const { t } = useTranslations()
+  const [nameEdits, setNameEdits] = useState<Record<string, string>>({})
+  const [rowErrors, setRowErrors] = useState<Record<string, string | null>>({})
+  const [renameLoading, setRenameLoading] = useState<string | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState<string | null>(null)
+  const [newAccountName, setNewAccountName] = useState("")
+  const [newAccountError, setNewAccountError] = useState<string | null>(null)
+  const [creatingAccount, setCreatingAccount] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setNewAccountName("")
+      setNewAccountError(null)
+      setRenameLoading(null)
+      setDeleteLoading(null)
+      setRowErrors({})
+    }
+  }, [open])
+
+  useEffect(() => {
+    const next: Record<string, string> = {}
+    accounts.forEach((account) => {
+      next[account.id] = account.name
+    })
+    setNameEdits(next)
+  }, [accounts])
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(undefined, {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+      }),
+    [],
+  )
+
+  const handleRename = async (id: string) => {
+    const nextName = nameEdits[id]?.trim() ?? ""
+    if (!nextName) {
+      setRowErrors((previous) => ({ ...previous, [id]: t("Account name is required") }))
+      return
+    }
+
+    setRowErrors((previous) => ({ ...previous, [id]: null }))
+    setRenameLoading(id)
+    try {
+      await onRename(id, nextName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("Unable to update account")
+      setRowErrors((previous) => ({ ...previous, [id]: message }))
+    } finally {
+      setRenameLoading(null)
+    }
+  }
+
+  const handleDelete = async (account: ManagedAccount) => {
+    const confirmed = window.confirm(
+      t("Delete {{name}}? This cannot be undone.", { values: { name: account.name } }),
+    )
+    if (!confirmed) {
+      return
+    }
+
+    setDeleteLoading(account.id)
+    try {
+      await onDelete(account.id)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("Unable to delete account")
+      setRowErrors((previous) => ({ ...previous, [account.id]: message }))
+    } finally {
+      setDeleteLoading(null)
+    }
+  }
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmed = newAccountName.trim()
+    if (!trimmed) {
+      setNewAccountError(t("Account name is required"))
+      return
+    }
+
+    setNewAccountError(null)
+    setCreatingAccount(true)
+    try {
+      await onCreate(trimmed)
+      setNewAccountName("")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("Unable to create account")
+      setNewAccountError(message)
+    } finally {
+      setCreatingAccount(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>{t("Manage accounts")}</DialogTitle>
+          <DialogDescription>
+            {t("Rename, add, or remove accounts used when logging transactions and transfers.")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <form onSubmit={handleCreate} className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="new-managed-account">{t("Add new account")}</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="new-managed-account"
+                  value={newAccountName}
+                  onChange={(event) => setNewAccountName(event.target.value)}
+                  placeholder={t("e.g. Travel fund") ?? undefined}
+                />
+                <Button type="submit" disabled={creatingAccount}>
+                  {creatingAccount ? t("Saving…") : t("Add")}
+                </Button>
+              </div>
+            </div>
+            {newAccountError && <p className="text-sm text-red-500">{newAccountError}</p>}
+          </form>
+
+          <Separator />
+
+          <div className="space-y-4">
+            {accounts.length === 0 && (
+              <p className="text-sm text-muted-foreground">{t("No accounts yet. Create one to get started.")}</p>
+            )}
+            {accounts.map((account) => {
+              const errorMessage = rowErrors[account.id]
+              const isRenaming = renameLoading === account.id
+              const isDeleting = deleteLoading === account.id
+              const netClass = account.balance >= 0 ? "text-green-600" : "text-red-600"
+
+              return (
+                <div
+                  key={account.id}
+                  className="rounded-lg border p-4"
+                >
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div className="flex-1 space-y-2">
+                      <Label htmlFor={`account-name-${account.id}`}>{t("Account name")}</Label>
+                      <Input
+                        id={`account-name-${account.id}`}
+                        value={nameEdits[account.id] ?? ""}
+                        onChange={(event) =>
+                          setNameEdits((previous) => ({ ...previous, [account.id]: event.target.value }))
+                        }
+                      />
+                      <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+                        <span>
+                          {t("Transactions: {{count}}", { values: { count: account.transactions.toString() } })}
+                        </span>
+                        <span className="text-green-600">
+                          {t("Inflow: {{value}}", { values: { value: currencyFormatter.format(account.inflow) } })}
+                        </span>
+                        <span className="text-red-600">
+                          {t("Outflow: {{value}}", { values: { value: currencyFormatter.format(account.outflow) } })}
+                        </span>
+                        <span className={netClass}>
+                          {t("Balance: {{value}}", { values: { value: currencyFormatter.format(account.balance) } })}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-start gap-2 md:items-end">
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleRename(account.id)}
+                          disabled={isRenaming || isDeleting}
+                        >
+                          {isRenaming ? t("Saving…") : t("Rename")}
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleDelete(account)}
+                          disabled={isRenaming || isDeleting}
+                        >
+                          {isDeleting ? t("Removing…") : t("Delete")}
+                        </Button>
+                      </div>
+                      {account.transactions > 0 && (
+                        <Badge variant="outline" className="text-xs">
+                          {t("{{count}} transactions", { values: { count: account.transactions.toString() } })}
+                        </Badge>
+                      )}
+                      {errorMessage && <p className="text-xs text-red-500">{errorMessage}</p>}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("Close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/charts/category-trend-chart.tsx
+++ b/components/charts/category-trend-chart.tsx
@@ -3,15 +3,9 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
 import { useTranslations } from "@/components/language-provider"
+import { DEFAULT_CHART_COLORS } from "@/lib/colors"
 
-const COLOR_PALETTE = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--destructive))",
-]
+const COLOR_PALETTE = DEFAULT_CHART_COLORS
 
 interface CategoryTrendChartProps {
   data: Array<{ month: string; [key: string]: number }>
@@ -84,10 +78,15 @@ export function CategoryTrendChart({ data, series }: CategoryTrendChartProps) {
             key={item.key}
             type="monotone"
             dataKey={item.key}
-            stroke={COLOR_PALETTE[index % COLOR_PALETTE.length]}
+            stroke={item.color ?? COLOR_PALETTE[index % COLOR_PALETTE.length]}
             strokeWidth={2}
             name={item.label}
-            dot={{ r: 3 }}
+            dot={{
+              r: 3,
+              stroke: item.color ?? COLOR_PALETTE[index % COLOR_PALETTE.length],
+              strokeWidth: 2,
+              fill: item.color ?? COLOR_PALETTE[index % COLOR_PALETTE.length],
+            }}
             isAnimationActive={false}
           />
         ))}

--- a/components/charts/income-expense-chart.tsx
+++ b/components/charts/income-expense-chart.tsx
@@ -3,6 +3,7 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
 import { useTranslations } from "@/components/language-provider"
+import { DEFAULT_CHART_COLORS } from "@/lib/colors"
 
 const DEFAULT_DATA = [
   { month: "Jul", income: 4200, expenses: 2325 },
@@ -87,8 +88,8 @@ export function IncomeExpenseChart({ data }: IncomeExpenseChartProps) {
         <Legend
           formatter={(value: string) => <span style={{ color: "hsl(var(--muted-foreground))" }}>{t(value)}</span>}
         />
-        <Bar dataKey="income" fill="hsl(var(--chart-1))" name={t("Income")} radius={[4, 4, 0, 0]} />
-        <Bar dataKey="expenses" fill="hsl(var(--chart-2))" name={t("Expenses")} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="income" fill={DEFAULT_CHART_COLORS[0]} name={t("Income")} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="expenses" fill={DEFAULT_CHART_COLORS[1]} name={t("Expenses")} radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/components/charts/monthly-breakdown-chart.tsx
+++ b/components/charts/monthly-breakdown-chart.tsx
@@ -3,15 +3,9 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts"
 
 import { useTranslations } from "@/components/language-provider"
+import { DEFAULT_CHART_COLORS } from "@/lib/colors"
 
-const COLOR_PALETTE = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--destructive))",
-]
+const COLOR_PALETTE = DEFAULT_CHART_COLORS
 
 const DEFAULT_DATA = [
   { name: "Bills & Utilities", value: 4350, color: COLOR_PALETTE[0] },

--- a/components/charts/spending-trend-chart.tsx
+++ b/components/charts/spending-trend-chart.tsx
@@ -3,6 +3,7 @@
 import { Area, AreaChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts"
 
 import { useTranslations } from "@/components/language-provider"
+import { DEFAULT_CHART_COLORS } from "@/lib/colors"
 
 interface SpendingTrendChartProps {
   data: Array<{ month: string; income: number; expenses: number }>
@@ -30,12 +31,12 @@ export function SpendingTrendChart({ data }: SpendingTrendChartProps) {
       <AreaChart data={data}>
         <defs>
           <linearGradient id="colorIncome" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="hsl(var(--chart-1))" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="hsl(var(--chart-1))" stopOpacity={0.1} />
+            <stop offset="5%" stopColor={DEFAULT_CHART_COLORS[0]} stopOpacity={0.8} />
+            <stop offset="95%" stopColor={DEFAULT_CHART_COLORS[0]} stopOpacity={0.1} />
           </linearGradient>
           <linearGradient id="colorExpenses" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="5%" stopColor="hsl(var(--chart-2))" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="hsl(var(--chart-2))" stopOpacity={0.1} />
+            <stop offset="5%" stopColor={DEFAULT_CHART_COLORS[1]} stopOpacity={0.8} />
+            <stop offset="95%" stopColor={DEFAULT_CHART_COLORS[1]} stopOpacity={0.1} />
           </linearGradient>
         </defs>
         <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
@@ -73,7 +74,7 @@ export function SpendingTrendChart({ data }: SpendingTrendChartProps) {
         <Area
           type="monotone"
           dataKey="income"
-          stroke="hsl(var(--chart-1))"
+          stroke={DEFAULT_CHART_COLORS[0]}
           fillOpacity={1}
           fill="url(#colorIncome)"
           strokeWidth={2}
@@ -81,7 +82,7 @@ export function SpendingTrendChart({ data }: SpendingTrendChartProps) {
         <Area
           type="monotone"
           dataKey="expenses"
-          stroke="hsl(var(--chart-2))"
+          stroke={DEFAULT_CHART_COLORS[1]}
           fillOpacity={1}
           fill="url(#colorExpenses)"
           strokeWidth={2}

--- a/components/charts/yearly-comparison-chart.tsx
+++ b/components/charts/yearly-comparison-chart.tsx
@@ -3,6 +3,10 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts"
 
 import { useTranslations } from "@/components/language-provider"
+import { DEFAULT_CHART_COLORS } from "@/lib/colors"
+
+const CURRENT_YEAR_COLOR = DEFAULT_CHART_COLORS[0]
+const PREVIOUS_YEAR_COLOR = DEFAULT_CHART_COLORS[2]
 
 const DEFAULT_DATA = [
   { month: "Jan", previous: 2400, current: 2200 },
@@ -84,8 +88,8 @@ export function YearlyComparisonChart({
           }}
         />
         <Legend formatter={(value: string) => <span style={{ color: "hsl(var(--muted-foreground))" }}>{t(value)}</span>} />
-        <Bar dataKey="previous" fill="hsl(var(--chart-2))" name={resolvedPreviousLabel} radius={[4, 4, 0, 0]} />
-        <Bar dataKey="current" fill="hsl(var(--chart-1))" name={resolvedCurrentLabel} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="previous" fill={PREVIOUS_YEAR_COLOR} name={resolvedPreviousLabel} radius={[4, 4, 0, 0]} />
+        <Bar dataKey="current" fill={CURRENT_YEAR_COLOR} name={resolvedCurrentLabel} radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/components/transaction-form-dialog.tsx
+++ b/components/transaction-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -12,12 +12,24 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { TransactionStatus, TransactionType } from "@/lib/transactions/types"
 import { useTranslations } from "@/components/language-provider"
 
 interface CategoryOption {
+  id: string
+  name: string
+}
+
+interface AccountOption {
   id: string
   name: string
 }
@@ -41,19 +53,21 @@ interface TransactionFormDialogProps {
   onSubmit: (values: TransactionFormValues) => Promise<void>
   initialValues?: TransactionFormValues
   categories: CategoryOption[]
+  accounts: AccountOption[]
+  onCreateAccount: (name: string) => Promise<AccountOption>
 }
-
-const accountOptions = ["Checking", "Savings", "Credit Card", "Cash", "Brokerage"]
 
 const statusOptions: TransactionStatus[] = ["completed", "pending", "cleared"]
 
-const createDefaultValues = (): TransactionFormValues => ({
+const NEW_ACCOUNT_VALUE = "__create_account__"
+
+const createDefaultValues = (defaultAccount = ""): TransactionFormValues => ({
   date: new Date().toISOString().split("T")[0],
   description: "",
   categoryId: null,
   categoryName: "Uncategorized",
   amount: "",
-  account: "",
+  account: defaultAccount,
   type: "expense",
   status: "completed",
   notes: "",
@@ -66,22 +80,55 @@ export function TransactionFormDialog({
   onSubmit,
   initialValues,
   categories,
+  accounts,
+  onCreateAccount,
 }: TransactionFormDialogProps) {
   const { t } = useTranslations()
   const [formData, setFormData] = useState<TransactionFormValues>(createDefaultValues)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isAccountDialogOpen, setIsAccountDialogOpen] = useState(false)
+  const [newAccountName, setNewAccountName] = useState("")
+  const [accountError, setAccountError] = useState<string | null>(null)
+  const [isCreatingAccount, setIsCreatingAccount] = useState(false)
+  const accountsRef = useRef<AccountOption[]>(accounts)
 
   useEffect(() => {
-    if (open) {
-      setError(null)
-      if (initialValues) {
-        setFormData({ ...initialValues })
-      } else {
-        setFormData(createDefaultValues())
+    accountsRef.current = accounts
+  }, [accounts])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setError(null)
+    if (initialValues) {
+      setFormData({ ...initialValues })
+      return
+    }
+
+    const defaultAccount = accountsRef.current[0]?.name ?? ""
+    setFormData(createDefaultValues(defaultAccount))
+  }, [open, initialValues])
+
+  const accountOptions = useMemo(() => {
+    const byName = new Map<string, AccountOption>()
+    accounts.forEach((account) => {
+      byName.set(account.name.toLowerCase(), account)
+    })
+
+    if (formData.account) {
+      const key = formData.account.toLowerCase()
+      if (!byName.has(key)) {
+        byName.set(key, { id: `local:${key}`, name: formData.account })
       }
     }
-  }, [open, initialValues])
+
+    return Array.from(byName.values()).sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+    )
+  }, [accounts, formData.account])
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -102,7 +149,8 @@ export function TransactionFormDialog({
       }
 
       await onSubmit(payload)
-      setFormData(createDefaultValues())
+      const defaultAccount = accountsRef.current[0]?.name ?? ""
+      setFormData(createDefaultValues(defaultAccount))
       onOpenChange(false)
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : t("Failed to save transaction"))
@@ -111,165 +159,246 @@ export function TransactionFormDialog({
     }
   }
 
+  const handleAccountSelect = (value: string) => {
+    if (value === NEW_ACCOUNT_VALUE) {
+      setAccountError(null)
+      setNewAccountName("")
+      setIsAccountDialogOpen(true)
+      return
+    }
+    setFormData((prev) => ({ ...prev, account: value }))
+  }
+
+  const handleAccountDialogChange = (nextOpen: boolean) => {
+    setIsAccountDialogOpen(nextOpen)
+    if (!nextOpen) {
+      setAccountError(null)
+      setNewAccountName("")
+    }
+  }
+
+  const handleCreateAccount = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmed = newAccountName.trim()
+    if (!trimmed) {
+      setAccountError(t("Account name is required"))
+      return
+    }
+
+    setAccountError(null)
+    setIsCreatingAccount(true)
+    try {
+      const account = await onCreateAccount(trimmed)
+      setFormData((prev) => ({ ...prev, account: account.name }))
+      handleAccountDialogChange(false)
+    } catch (createError) {
+      const message =
+        createError instanceof Error ? createError.message : t("Unable to create account")
+      setAccountError(message)
+    } finally {
+      setIsCreatingAccount(false)
+    }
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[520px]">
-        <DialogHeader>
-          <DialogTitle>{mode === "create" ? t("Add Transaction") : t("Edit Transaction")}</DialogTitle>
-          <DialogDescription>
-            {mode === "create"
-              ? t("Add a new transaction to your account")
-              : t("Update the details of your transaction")}
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle>{mode === "create" ? t("Add Transaction") : t("Edit Transaction")}</DialogTitle>
+            <DialogDescription>
+              {mode === "create"
+                ? t("Add a new transaction to your account")
+                : t("Update the details of your transaction")}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transaction-date">{t("Date")}</Label>
+                <Input
+                  id="transaction-date"
+                  type="date"
+                  value={formData.date}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, date: event.target.value }))}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="transaction-type">{t("Type")}</Label>
+                <Select
+                  value={formData.type}
+                  onValueChange={(value: TransactionType) => setFormData((prev) => ({ ...prev, type: value }))}
+                >
+                  <SelectTrigger id="transaction-type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="expense">{t("Expense")}</SelectItem>
+                    <SelectItem value="income">{t("Income")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
             <div className="space-y-2">
-              <Label htmlFor="transaction-date">{t("Date")}</Label>
+              <Label htmlFor="transaction-description">{t("Description")}</Label>
               <Input
-                id="transaction-date"
-                type="date"
-                value={formData.date}
-                onChange={(event) => setFormData((prev) => ({ ...prev, date: event.target.value }))}
+                id="transaction-description"
+                placeholder={t("Enter transaction description")}
+                value={formData.description}
+                onChange={(event) => setFormData((prev) => ({ ...prev, description: event.target.value }))}
                 required
               />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="transaction-type">{t("Type")}</Label>
-              <Select
-                value={formData.type}
-                onValueChange={(value: TransactionType) => setFormData((prev) => ({ ...prev, type: value }))}
-              >
-                <SelectTrigger id="transaction-type">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="expense">{t("Expense")}</SelectItem>
-                  <SelectItem value="income">{t("Income")}</SelectItem>
-                </SelectContent>
-              </Select>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transaction-category">{t("Category")}</Label>
+                <Select
+                  value={formData.categoryId ?? formData.categoryName ?? "uncategorized"}
+                  onValueChange={(value) => {
+                    if (value === "uncategorized") {
+                      setFormData((prev) => ({ ...prev, categoryId: null, categoryName: "Uncategorized" }))
+                    } else {
+                      const option = categories.find((category) => category.id === value)
+                      setFormData((prev) => ({
+                        ...prev,
+                        categoryId: option?.id ?? null,
+                        categoryName: option?.name ?? "Uncategorized",
+                      }))
+                    }
+                  }}
+                >
+                  <SelectTrigger id="transaction-category">
+                    <SelectValue placeholder={t("Select category") ?? undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="uncategorized">{t("Uncategorized")}</SelectItem>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.id}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="transaction-amount">{t("Amount")}</Label>
+                <Input
+                  id="transaction-amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder="0.00"
+                  value={formData.amount}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, amount: event.target.value }))}
+                  required
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="transaction-description">{t("Description")}</Label>
-            <Input
-              id="transaction-description"
-              placeholder={t("Enter transaction description")}
-              value={formData.description}
-              onChange={(event) => setFormData((prev) => ({ ...prev, description: event.target.value }))}
-              required
-            />
-          </div>
-
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="transaction-category">{t("Category")}</Label>
-              <Select
-                value={formData.categoryId ?? formData.categoryName ?? "uncategorized"}
-                onValueChange={(value) => {
-                  if (value === "uncategorized") {
-                    setFormData((prev) => ({ ...prev, categoryId: null, categoryName: "Uncategorized" }))
-                  } else {
-                    const option = categories.find((category) => category.id === value)
-                    setFormData((prev) => ({
-                      ...prev,
-                      categoryId: option?.id ?? null,
-                      categoryName: option?.name ?? "Uncategorized",
-                    }))
-                  }
-                }}
-              >
-                <SelectTrigger id="transaction-category">
-                  <SelectValue placeholder={t("Select category") ?? undefined} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="uncategorized">{t("Uncategorized")}</SelectItem>
-                  {categories.map((category) => (
-                    <SelectItem key={category.id} value={category.id}>
-                      {category.name}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transaction-account">{t("Account")}</Label>
+                <Select value={formData.account} onValueChange={handleAccountSelect}>
+                  <SelectTrigger id="transaction-account">
+                    <SelectValue placeholder={t("Select account") ?? undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accountOptions.map((account) => (
+                      <SelectItem key={account.id} value={account.name}>
+                        {account.name}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    <SelectItem value={NEW_ACCOUNT_VALUE} className="font-medium text-primary">
+                      {t("Create new account")}
                     </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="transaction-status">{t("Status")}</Label>
+                <Select
+                  value={formData.status}
+                  onValueChange={(value: TransactionStatus) => setFormData((prev) => ({ ...prev, status: value }))}
+                >
+                  <SelectTrigger id="transaction-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {statusOptions.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {t(status.charAt(0).toUpperCase() + status.slice(1))}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="transaction-amount">{t("Amount")}</Label>
-              <Input
-                id="transaction-amount"
-                type="number"
-                step="0.01"
-                min="0"
-                placeholder="0.00"
-                value={formData.amount}
-                onChange={(event) => setFormData((prev) => ({ ...prev, amount: event.target.value }))}
-                required
+              <Label htmlFor="transaction-notes">{t("Notes (optional)")}</Label>
+              <Textarea
+                id="transaction-notes"
+                placeholder={t("Add any additional details")}
+                value={formData.notes}
+                onChange={(event) => setFormData((prev) => ({ ...prev, notes: event.target.value }))}
+                rows={3}
               />
             </div>
-          </div>
 
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {error && <p className="text-sm text-red-500">{error}</p>}
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                {t("Cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t("Saving…") : mode === "create" ? t("Add Transaction") : t("Save Changes")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isAccountDialogOpen} onOpenChange={handleAccountDialogChange}>
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>{t("Create account")}</DialogTitle>
+            <DialogDescription>
+              {t("Add a new account to keep transactions organized by where money is stored or spent.")}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateAccount} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="transaction-account">{t("Account")}</Label>
-              <Select
-                value={formData.account}
-                onValueChange={(value) => setFormData((prev) => ({ ...prev, account: value }))}
-              >
-                <SelectTrigger id="transaction-account">
-                  <SelectValue placeholder={t("Select account") ?? undefined} />
-                </SelectTrigger>
-                <SelectContent>
-                  {accountOptions.map((account) => (
-                    <SelectItem key={account} value={account}>
-                      {t(account)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Label htmlFor="new-account-name">{t("Account name")}</Label>
+              <Input
+                id="new-account-name"
+                value={newAccountName}
+                onChange={(event) => setNewAccountName(event.target.value)}
+                placeholder={t("e.g. Checking, Savings, Credit Card") ?? undefined}
+                autoFocus
+              />
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="transaction-status">{t("Status")}</Label>
-              <Select
-                value={formData.status}
-                onValueChange={(value: TransactionStatus) => setFormData((prev) => ({ ...prev, status: value }))}
+            {accountError && <p className="text-sm text-red-500">{accountError}</p>}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleAccountDialogChange(false)}
+                disabled={isCreatingAccount}
               >
-                <SelectTrigger id="transaction-status">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {statusOptions.map((status) => (
-                    <SelectItem key={status} value={status}>
-                      {t(status.charAt(0).toUpperCase() + status.slice(1))}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="transaction-notes">{t("Notes (optional)")}</Label>
-            <Textarea
-              id="transaction-notes"
-              placeholder={t("Add any additional details")}
-              value={formData.notes}
-              onChange={(event) => setFormData((prev) => ({ ...prev, notes: event.target.value }))}
-              rows={3}
-            />
-          </div>
-
-          {error && <p className="text-sm text-red-500">{error}</p>}
-
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
-              {t("Cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? t("Saving…") : mode === "create" ? t("Add Transaction") : t("Save Changes")}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+                {t("Cancel")}
+              </Button>
+              <Button type="submit" disabled={isCreatingAccount}>
+                {isCreatingAccount ? t("Saving…") : t("Create account")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/components/transfer-dialog.tsx
+++ b/components/transfer-dialog.tsx
@@ -1,0 +1,375 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { TransactionStatus } from "@/lib/transactions/types"
+import { useTranslations } from "@/components/language-provider"
+
+interface AccountOption {
+  id: string
+  name: string
+}
+
+export interface TransferFormValues {
+  date: string
+  description: string
+  amount: string
+  fromAccount: string
+  toAccount: string
+  status: TransactionStatus
+  notes: string
+}
+
+interface TransferDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accounts: AccountOption[]
+  onSubmit: (values: TransferFormValues) => Promise<void>
+  onCreateAccount: (name: string) => Promise<AccountOption>
+}
+
+const statusOptions: TransactionStatus[] = ["completed", "pending", "cleared"]
+const NEW_ACCOUNT_VALUE = "__create_account__"
+
+export function TransferDialog({
+  open,
+  onOpenChange,
+  accounts,
+  onSubmit,
+  onCreateAccount,
+}: TransferDialogProps) {
+  const { t } = useTranslations()
+  const [formData, setFormData] = useState<TransferFormValues>({
+    date: new Date().toISOString().split("T")[0],
+    description: "",
+    amount: "",
+    fromAccount: "",
+    toAccount: "",
+    status: "completed",
+    notes: "",
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [accountError, setAccountError] = useState<string | null>(null)
+  const [isAccountDialogOpen, setIsAccountDialogOpen] = useState(false)
+  const [newAccountName, setNewAccountName] = useState("")
+  const [isCreatingAccount, setIsCreatingAccount] = useState(false)
+  const [accountDialogTarget, setAccountDialogTarget] = useState<"from" | "to" | null>(null)
+  const accountsRef = useRef<AccountOption[]>(accounts)
+
+  useEffect(() => {
+    accountsRef.current = accounts
+  }, [accounts])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    setError(null)
+    const defaultAccount = accountsRef.current[0]?.name ?? ""
+    setFormData((previous) => ({
+      ...previous,
+      date: new Date().toISOString().split("T")[0],
+      fromAccount: previous.fromAccount || defaultAccount,
+      toAccount: previous.toAccount && previous.toAccount !== previous.fromAccount ? previous.toAccount : "",
+      amount: "",
+    }))
+  }, [open])
+
+  const accountOptions = useMemo(() => {
+    const unique = new Map<string, AccountOption>()
+    accounts.forEach((account) => {
+      unique.set(account.name.toLowerCase(), account)
+    })
+    if (formData.fromAccount) {
+      const key = formData.fromAccount.toLowerCase()
+      if (!unique.has(key)) {
+        unique.set(key, { id: `local:${key}`, name: formData.fromAccount })
+      }
+    }
+    if (formData.toAccount) {
+      const key = formData.toAccount.toLowerCase()
+      if (!unique.has(key)) {
+        unique.set(key, { id: `local:${key}`, name: formData.toAccount })
+      }
+    }
+    return Array.from(unique.values()).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
+  }, [accounts, formData.fromAccount, formData.toAccount])
+
+  const resetAccountDialog = () => {
+    setAccountError(null)
+    setNewAccountName("")
+    setAccountDialogTarget(null)
+  }
+
+  const handleAccountSelect = (value: string, target: "from" | "to") => {
+    if (value === NEW_ACCOUNT_VALUE) {
+      setAccountDialogTarget(target)
+      setIsAccountDialogOpen(true)
+      setAccountError(null)
+      setNewAccountName("")
+      return
+    }
+    setFormData((prev) => ({ ...prev, [target === "from" ? "fromAccount" : "toAccount"]: value }))
+  }
+
+  const handleAccountDialogChange = (nextOpen: boolean) => {
+    setIsAccountDialogOpen(nextOpen)
+    if (!nextOpen) {
+      resetAccountDialog()
+    }
+  }
+
+  const handleCreateAccount = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmed = newAccountName.trim()
+    if (!trimmed) {
+      setAccountError(t("Account name is required"))
+      return
+    }
+    setAccountError(null)
+    setIsCreatingAccount(true)
+    try {
+      const account = await onCreateAccount(trimmed)
+      setFormData((prev) => ({
+        ...prev,
+        [accountDialogTarget === "to" ? "toAccount" : "fromAccount"]: account.name,
+      }))
+      handleAccountDialogChange(false)
+    } catch (createError) {
+      const message =
+        createError instanceof Error ? createError.message : t("Unable to create account")
+      setAccountError(message)
+    } finally {
+      setIsCreatingAccount(false)
+    }
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    if (!formData.fromAccount || !formData.toAccount) {
+      setError(t("Select both source and destination accounts"))
+      return
+    }
+    if (formData.fromAccount.trim().toLowerCase() === formData.toAccount.trim().toLowerCase()) {
+      setError(t("Choose two different accounts for a transfer"))
+      return
+    }
+    if (!formData.amount) {
+      setError(t("Amount is required"))
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await onSubmit(formData)
+      setFormData({
+        date: new Date().toISOString().split("T")[0],
+        description: "",
+        amount: "",
+        fromAccount: formData.fromAccount,
+        toAccount: "",
+        status: formData.status,
+        notes: "",
+      })
+      onOpenChange(false)
+    } catch (submitError) {
+      const message =
+        submitError instanceof Error ? submitError.message : t("Unable to create transfer")
+      setError(message)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle>{t("New Transfer")}</DialogTitle>
+            <DialogDescription>
+              {t("Move money between your accounts without affecting your budgets.")}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transfer-date">{t("Date")}</Label>
+                <Input
+                  id="transfer-date"
+                  type="date"
+                  value={formData.date}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, date: event.target.value }))}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="transfer-status">{t("Status")}</Label>
+                <Select
+                  value={formData.status}
+                  onValueChange={(value: TransactionStatus) =>
+                    setFormData((prev) => ({ ...prev, status: value }))
+                  }
+                >
+                  <SelectTrigger id="transfer-status">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {statusOptions.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {t(status.charAt(0).toUpperCase() + status.slice(1))}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="transfer-description">{t("Description")}</Label>
+              <Input
+                id="transfer-description"
+                placeholder={t("e.g. Move funds to savings") ?? undefined}
+                value={formData.description}
+                onChange={(event) => setFormData((prev) => ({ ...prev, description: event.target.value }))}
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transfer-from">{t("From account")}</Label>
+                <Select value={formData.fromAccount} onValueChange={(value) => handleAccountSelect(value, "from")}>
+                  <SelectTrigger id="transfer-from">
+                    <SelectValue placeholder={t("Select account") ?? undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accountOptions.map((account) => (
+                      <SelectItem key={account.id} value={account.name}>
+                        {account.name}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    <SelectItem value={NEW_ACCOUNT_VALUE} className="font-medium text-primary">
+                      {t("Create new account")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="transfer-to">{t("To account")}</Label>
+                <Select value={formData.toAccount} onValueChange={(value) => handleAccountSelect(value, "to")}>
+                  <SelectTrigger id="transfer-to">
+                    <SelectValue placeholder={t("Select account") ?? undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {accountOptions.map((account) => (
+                      <SelectItem key={account.id} value={account.name}>
+                        {account.name}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    <SelectItem value={NEW_ACCOUNT_VALUE} className="font-medium text-primary">
+                      {t("Create new account")}
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="transfer-amount">{t("Amount")}</Label>
+                <Input
+                  id="transfer-amount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={formData.amount}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, amount: event.target.value }))}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="transfer-notes">{t("Notes (optional)")}</Label>
+              <Textarea
+                id="transfer-notes"
+                rows={3}
+                value={formData.notes}
+                onChange={(event) => setFormData((prev) => ({ ...prev, notes: event.target.value }))}
+                placeholder={t("Add any additional details") ?? undefined}
+              />
+            </div>
+
+            {error && <p className="text-sm text-red-500">{error}</p>}
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                {t("Cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t("Saving…") : t("Create transfer")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isAccountDialogOpen} onOpenChange={handleAccountDialogChange}>
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>{t("Create account")}</DialogTitle>
+            <DialogDescription>
+              {t("Add a new account to keep transfers organized.")}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleCreateAccount} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="transfer-new-account">{t("Account name")}</Label>
+              <Input
+                id="transfer-new-account"
+                value={newAccountName}
+                onChange={(event) => setNewAccountName(event.target.value)}
+                placeholder={t("e.g. Savings, Credit Card") ?? undefined}
+                autoFocus
+              />
+            </div>
+            {accountError && <p className="text-sm text-red-500">{accountError}</p>}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => handleAccountDialogChange(false)} disabled={isCreatingAccount}>
+                {t("Cancel")}
+              </Button>
+              <Button type="submit" disabled={isCreatingAccount}>
+                {isCreatingAccount ? t("Saving…") : t("Create account")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/lib/accounts/repository.ts
+++ b/lib/accounts/repository.ts
@@ -1,0 +1,177 @@
+import type Database from "better-sqlite3"
+
+import { getDatabase, initDatabase } from "@/lib/db"
+import { recordSyncLog } from "@/lib/db/sync-log"
+import type { Account } from "@/lib/accounts/types"
+
+const databaseReady = initDatabase()
+
+interface AccountRow {
+  id: string
+  name: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AccountFilters {
+  ids?: string[]
+  names?: string[]
+  search?: string
+  updatedSince?: string
+}
+
+async function resolveDatabase(db?: Database): Promise<Database> {
+  if (db) {
+    return db
+  }
+  await databaseReady
+  return getDatabase()
+}
+
+function mapRow(row: AccountRow): Account {
+  return {
+    id: row.id,
+    name: row.name,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export async function listAccounts(filters: AccountFilters = {}, db?: Database): Promise<Account[]> {
+  const connection = await resolveDatabase(db)
+  const clauses: string[] = []
+  const parameters: unknown[] = []
+
+  if (filters.ids?.length) {
+    clauses.push(`id IN (${filters.ids.map(() => "?").join(", ")})`)
+    parameters.push(...filters.ids)
+  }
+
+  if (filters.names?.length) {
+    clauses.push(`name IN (${filters.names.map(() => "?").join(", ")})`)
+    parameters.push(...filters.names)
+  }
+
+  if (filters.search) {
+    clauses.push(`name LIKE ?`)
+    parameters.push(`%${filters.search.replace(/%/g, "%%")}%`)
+  }
+
+  if (filters.updatedSince) {
+    clauses.push(`updatedAt > ?`)
+    parameters.push(filters.updatedSince)
+  }
+
+  let sql = "SELECT id, name, createdAt, updatedAt FROM accounts"
+  if (clauses.length > 0) {
+    sql += ` WHERE ${clauses.join(" AND ")}`
+  }
+  sql += " ORDER BY name COLLATE NOCASE"
+
+  const rows = connection.prepare(sql).all(...parameters) as AccountRow[]
+  return rows.map(mapRow)
+}
+
+export async function getAccountById(id: string, db?: Database): Promise<Account | null> {
+  const connection = await resolveDatabase(db)
+  const row = connection
+    .prepare("SELECT id, name, createdAt, updatedAt FROM accounts WHERE id = ?")
+    .get(id) as AccountRow | undefined
+  return row ? mapRow(row) : null
+}
+
+export async function getAccountByName(name: string, db?: Database): Promise<Account | null> {
+  const connection = await resolveDatabase(db)
+  const row = connection
+    .prepare("SELECT id, name, createdAt, updatedAt FROM accounts WHERE name = ? COLLATE NOCASE")
+    .get(name) as AccountRow | undefined
+  return row ? mapRow(row) : null
+}
+
+export interface CreateAccountRecord {
+  id: string
+  name: string
+}
+
+export interface UpdateAccountRecord {
+  name?: string
+}
+
+export async function insertAccount(record: CreateAccountRecord, db?: Database): Promise<Account> {
+  const connection = await resolveDatabase(db)
+  const timestamp = new Date().toISOString()
+  const row: AccountRow = {
+    ...record,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+
+  connection
+    .prepare("INSERT INTO accounts (id, name, createdAt, updatedAt) VALUES (@id, @name, @createdAt, @updatedAt)")
+    .run(row)
+
+  recordSyncLog(connection, "account", row.id, row.updatedAt)
+  return mapRow(row)
+}
+
+export async function updateAccount(id: string, updates: UpdateAccountRecord, db?: Database): Promise<Account | null> {
+  const connection = await resolveDatabase(db)
+  const existing = await getAccountById(id, connection)
+  if (!existing) {
+    return null
+  }
+
+  const updatedRow: AccountRow = {
+    ...existing,
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  }
+
+  connection
+    .prepare("UPDATE accounts SET name = @name, updatedAt = @updatedAt WHERE id = @id")
+    .run(updatedRow)
+
+  recordSyncLog(connection, "account", updatedRow.id, updatedRow.updatedAt)
+  return mapRow(updatedRow)
+}
+
+export async function deleteAccount(id: string, db?: Database): Promise<boolean> {
+  const connection = await resolveDatabase(db)
+  const result = connection.prepare("DELETE FROM accounts WHERE id = ?").run(id)
+  if (result.changes > 0) {
+    const timestamp = new Date().toISOString()
+    recordSyncLog(connection, "account", id, timestamp)
+    return true
+  }
+  return false
+}
+
+export async function bulkUpsertAccounts(records: CreateAccountRecord[], db?: Database): Promise<Account[]> {
+  if (records.length === 0) {
+    return []
+  }
+
+  const connection = await resolveDatabase(db)
+  const statement = connection.prepare(
+    `INSERT INTO accounts (id, name, createdAt, updatedAt)
+     VALUES (@id, @name, @createdAt, @updatedAt)
+     ON CONFLICT(id) DO UPDATE SET
+       name = excluded.name,
+       updatedAt = excluded.updatedAt`,
+  )
+
+  const results: Account[] = []
+  for (const record of records) {
+    const timestamp = new Date().toISOString()
+    const row: AccountRow = {
+      ...record,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }
+    statement.run(row)
+    recordSyncLog(connection, "account", row.id, row.updatedAt)
+    results.push(mapRow(row))
+  }
+
+  return results
+}

--- a/lib/accounts/service.ts
+++ b/lib/accounts/service.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "crypto"
+import type Database from "better-sqlite3"
+
+import { getDatabase } from "@/lib/db"
+import {
+  bulkUpsertAccounts,
+  deleteAccount as deleteAccountRecord,
+  getAccountById,
+  getAccountByName,
+  insertAccount,
+  listAccounts as listAccountRecords,
+  updateAccount as updateAccountRecord,
+  type AccountFilters,
+} from "@/lib/accounts/repository"
+import type { Account, AccountWithBalance, CreateAccountInput, UpdateAccountInput } from "@/lib/accounts/types"
+
+function normalizeName(name: string): string {
+  return name.trim()
+}
+
+export async function listAccounts(filters: AccountFilters = {}): Promise<Account[]> {
+  return listAccountRecords(filters)
+}
+
+export async function listAccountsWithBalances(): Promise<AccountWithBalance[]> {
+  const db = getDatabase()
+  const accounts = await listAccountRecords({}, db)
+  const accountMap = new Map<string, AccountWithBalance>()
+
+  accounts.forEach((account) => {
+    accountMap.set(account.name.toLowerCase(), {
+      ...account,
+      balance: 0,
+      inflow: 0,
+      outflow: 0,
+      transactions: 0,
+    })
+  })
+
+  const rows = db
+    .prepare(
+      `SELECT
+         account AS name,
+         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS inflow,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS outflow,
+         SUM(amount) AS balance,
+         COUNT(id) AS transactions
+       FROM transactions
+       GROUP BY account`,
+    )
+    .all() as Array<{
+      name: string | null
+      inflow: number | null
+      outflow: number | null
+      balance: number | null
+      transactions: number | null
+    }>
+
+  for (const row of rows) {
+    const name = (row.name ?? "Unspecified").trim() || "Unspecified"
+    const key = name.toLowerCase()
+    const inflow = Number(row.inflow ?? 0)
+    const outflow = Number(row.outflow ?? 0)
+    const balance = Number(row.balance ?? 0)
+    const transactions = Number(row.transactions ?? 0)
+
+    const existing = accountMap.get(key)
+    if (existing) {
+      existing.inflow = inflow
+      existing.outflow = outflow
+      existing.balance = balance
+      existing.transactions = transactions
+      continue
+    }
+
+    const ensured = await ensureAccountExists(name, db)
+    accountMap.set(ensured.name.toLowerCase(), {
+      ...ensured,
+      inflow,
+      outflow,
+      balance,
+      transactions,
+    })
+  }
+
+  return Array.from(accountMap.values()).sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
+}
+
+export async function createAccount(input: CreateAccountInput): Promise<Account> {
+  const name = normalizeName(input.name)
+  if (!name) {
+    throw new Error("Account name is required")
+  }
+
+  const existing = await getAccountByName(name)
+  if (existing) {
+    throw new Error("An account with this name already exists")
+  }
+
+  return insertAccount({ id: `acct_${randomUUID()}`, name })
+}
+
+export async function updateAccount(id: string, updates: UpdateAccountInput): Promise<Account> {
+  const existing = await getAccountById(id)
+  if (!existing) {
+    throw new Error("Account not found")
+  }
+
+  if (updates.name) {
+    const normalized = normalizeName(updates.name)
+    if (!normalized) {
+      throw new Error("Account name is required")
+    }
+    const duplicate = await getAccountByName(normalized)
+    if (duplicate && duplicate.id !== id) {
+      throw new Error("Another account already uses this name")
+    }
+    const updated = await updateAccountRecord(id, { name: normalized })
+    if (!updated) {
+      throw new Error("Unable to update account")
+    }
+    const db = getDatabase()
+    db.prepare("UPDATE transactions SET account = ? WHERE account = ? COLLATE NOCASE").run(updated.name, existing.name)
+    return updated
+  }
+
+  return existing
+}
+
+export async function deleteAccount(id: string): Promise<void> {
+  const existing = await getAccountById(id)
+  if (!existing) {
+    throw new Error("Account not found")
+  }
+
+  const db = getDatabase()
+  const usage = db
+    .prepare("SELECT COUNT(*) as count FROM transactions WHERE account = ? COLLATE NOCASE")
+    .get(existing.name) as { count: number | null } | undefined
+
+  if (Number(usage?.count ?? 0) > 0) {
+    throw new Error("Cannot delete an account with existing transactions")
+  }
+
+  const deleted = await deleteAccountRecord(id)
+  if (!deleted) {
+    throw new Error("Account not found")
+  }
+}
+
+export async function ensureAccountExists(name: string, db?: Database): Promise<Account> {
+  const normalized = normalizeName(name)
+  if (!normalized) {
+    throw new Error("Account name is required")
+  }
+
+  const existing = await getAccountByName(normalized, db)
+  if (existing) {
+    return existing
+  }
+
+  return insertAccount({ id: `acct_${randomUUID()}`, name: normalized }, db)
+}
+
+export async function upsertAccounts(records: Array<{ id: string; name: string }>, db?: Database) {
+  await bulkUpsertAccounts(records, db)
+}
+
+export async function listAccountsForSync(updatedSince?: string): Promise<Account[]> {
+  return listAccountRecords(updatedSince ? { updatedSince } : {})
+}

--- a/lib/accounts/types.ts
+++ b/lib/accounts/types.ts
@@ -1,0 +1,21 @@
+export interface Account {
+  id: string
+  name: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AccountWithBalance extends Account {
+  balance: number
+  inflow: number
+  outflow: number
+  transactions: number
+}
+
+export interface CreateAccountInput {
+  name: string
+}
+
+export interface UpdateAccountInput {
+  name?: string
+}

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,0 +1,47 @@
+const TAILWIND_BG_COLOR_MAP: Record<string, string> = {
+  "bg-slate-500": "#64748b",
+  "bg-gray-500": "#6b7280",
+  "bg-zinc-500": "#71717a",
+  "bg-neutral-500": "#737373",
+  "bg-stone-500": "#78716c",
+  "bg-red-500": "#ef4444",
+  "bg-orange-500": "#f97316",
+  "bg-amber-500": "#f59e0b",
+  "bg-yellow-500": "#eab308",
+  "bg-lime-500": "#84cc16",
+  "bg-green-500": "#22c55e",
+  "bg-emerald-500": "#10b981",
+  "bg-teal-500": "#14b8a6",
+  "bg-cyan-500": "#06b6d4",
+  "bg-sky-500": "#0ea5e9",
+  "bg-blue-500": "#3b82f6",
+  "bg-indigo-500": "#6366f1",
+  "bg-violet-500": "#8b5cf6",
+  "bg-purple-500": "#a855f7",
+  "bg-fuchsia-500": "#d946ef",
+  "bg-pink-500": "#ec4899",
+  "bg-rose-500": "#f43f5e",
+}
+
+export function tailwindBgClassToHex(colorClass: string | null | undefined, fallback = "#64748b"): string {
+  if (!colorClass) {
+    return fallback
+  }
+
+  const direct = TAILWIND_BG_COLOR_MAP[colorClass]
+  if (direct) {
+    return direct
+  }
+
+  const normalized = colorClass.trim().toLowerCase()
+  return TAILWIND_BG_COLOR_MAP[normalized] ?? fallback
+}
+
+export const DEFAULT_CHART_COLORS = [
+  "#6366F1",
+  "#22C55E",
+  "#F97316",
+  "#0EA5E9",
+  "#EC4899",
+  "#FACC15",
+]

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -21,6 +21,15 @@ export const CREATE_CATEGORIES_TABLE = `
   )
 `
 
+export const CREATE_ACCOUNTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS accounts (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    createdAt TEXT NOT NULL,
+    updatedAt TEXT NOT NULL
+  )
+`
+
 export const CREATE_TRANSACTIONS_TABLE = `
   CREATE TABLE IF NOT EXISTS transactions (
     id TEXT PRIMARY KEY,
@@ -33,6 +42,8 @@ export const CREATE_TRANSACTIONS_TABLE = `
     status TEXT NOT NULL,
     type TEXT NOT NULL,
     notes TEXT,
+    transferGroupId TEXT,
+    transferDirection TEXT,
     createdAt TEXT NOT NULL,
     updatedAt TEXT NOT NULL,
     FOREIGN KEY (categoryId) REFERENCES categories(id) ON UPDATE CASCADE ON DELETE SET NULL

--- a/lib/db/sync-log.ts
+++ b/lib/db/sync-log.ts
@@ -6,6 +6,7 @@ import { prepareStatement } from "./client"
 export type SyncEntityType =
   | "transaction"
   | "category"
+  | "account"
   | "automation_rule"
   | "user"
   | "setting"

--- a/lib/reports/analytics.ts
+++ b/lib/reports/analytics.ts
@@ -1,6 +1,8 @@
 import { initDatabase, getDatabase } from "@/lib/db"
 import type Database from "better-sqlite3"
 
+import { tailwindBgClassToHex, DEFAULT_CHART_COLORS } from "@/lib/colors"
+
 export type ReportPeriodKey = "last-3-months" | "last-6-months" | "last-12-months" | "current-year"
 
 interface CategoryRow {
@@ -41,6 +43,18 @@ interface YearlySpendRow {
   expenses: number
 }
 
+interface AccountRow {
+  id: string
+  name: string
+}
+
+interface AccountActivityRow {
+  name: string
+  inflow: number
+  outflow: number
+  transactions: number
+}
+
 export interface SummaryMetric {
   label: string
   value: number
@@ -57,6 +71,7 @@ export interface CategoryPerformance {
   change: number | null
   transactions: number
   colorClass: string
+  colorHex: string
 }
 
 export interface ChartPoint {
@@ -68,6 +83,16 @@ export interface ChartPoint {
 export interface ChartSeries {
   key: string
   label: string
+  color?: string
+}
+
+export interface AccountSummary {
+  id: string
+  name: string
+  inflow: number
+  outflow: number
+  net: number
+  transactions: number
 }
 
 export interface ReportAnalytics {
@@ -83,18 +108,12 @@ export interface ReportAnalytics {
   categoryTrend: { data: Array<{ month: string; [key: string]: number }>; series: ChartSeries[] }
   yearlyComparison: Array<{ month: string; current: number; previous: number }>
   insights: Array<{ variant: "positive" | "warning" | "info"; title: string; description: string }>
+  accounts: AccountSummary[]
 }
 
 const databaseReady = initDatabase()
 
-const CHART_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
-  "hsl(var(--destructive))",
-]
+const CHART_COLORS = DEFAULT_CHART_COLORS
 
 const PERIOD_MONTHS: Record<Exclude<ReportPeriodKey, "current-year">, number> = {
   "last-3-months": 3,
@@ -192,7 +211,8 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS income,
          SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
        FROM transactions
-       WHERE date >= @start AND date < @end`,
+       WHERE date >= @start AND date < @end
+         AND type != 'transfer'`,
     )
     .get({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as
     | { income: number | null; expenses: number | null }
@@ -204,7 +224,8 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS income,
          SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
        FROM transactions
-       WHERE date >= @start AND date < @end`,
+       WHERE date >= @start AND date < @end
+         AND type != 'transfer'`,
     )
     .get({ start: previousStart.toISOString().slice(0, 10), end: previousEnd.toISOString().slice(0, 10) }) as
     | { income: number | null; expenses: number | null }
@@ -266,6 +287,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount < 0 THEN 1 ELSE 0 END) AS transactions
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY categoryId, categoryName`,
     )
     .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as CategorySpendRow[]
@@ -278,6 +300,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS spent
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY categoryId, categoryName`,
     )
     .all({ start: previousStart.toISOString().slice(0, 10), end: previousEnd.toISOString().slice(0, 10) }) as CategorySpendPreviousRow[]
@@ -302,6 +325,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
     const monthlyBudget = Number(base?.monthlyBudget ?? 0)
     const budget = monthlyBudget * (monthsInPeriod > 0 ? monthsInPeriod : 1)
     const colorClass = normalizeCategoryColor(base?.color)
+    const colorHex = tailwindBgClassToHex(colorClass)
     const change = calculateChange(spent, previousSpent)
 
     categoryPerformances.push({
@@ -312,6 +336,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
       change,
       transactions,
       colorClass,
+      colorHex,
     })
   })
 
@@ -338,6 +363,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY SUBSTR(date, 1, 7)`
     )
     .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as MonthlySpendRow[]
@@ -363,6 +389,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
          SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS spent
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY SUBSTR(date, 1, 7), categoryId, categoryName`
     )
     .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as CategoryMonthlySpendRow[]
@@ -370,6 +397,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
   const trendSeries: ChartSeries[] = categoryPerformances.slice(0, 5).map((category) => ({
     key: getCategoryKey(category.id === category.name ? null : category.id, category.name),
     label: category.name,
+    color: category.colorHex,
   }))
 
   const trendData = monthKeys.map((key) => {
@@ -386,7 +414,11 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
   const monthlyBreakdown = categoryPerformances
     .filter((category) => category.spent > 0)
     .slice(0, CHART_COLORS.length)
-    .map((category, index) => ({ name: category.name, value: category.spent, color: CHART_COLORS[index % CHART_COLORS.length] }))
+    .map((category, index) => ({
+      name: category.name,
+      value: category.spent,
+      color: category.colorHex || CHART_COLORS[index % CHART_COLORS.length],
+    }))
 
   const currentYearStart = new Date(start.getFullYear(), 0, 1)
   const nextYearStart = new Date(start.getFullYear() + 1, 0, 1)
@@ -397,6 +429,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
       `SELECT SUBSTR(date, 1, 7) AS month, SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY SUBSTR(date, 1, 7)`
     )
     .all({ start: currentYearStart.toISOString().slice(0, 10), end: nextYearStart.toISOString().slice(0, 10) }) as YearlySpendRow[]
@@ -406,6 +439,7 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
       `SELECT SUBSTR(date, 1, 7) AS month, SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS expenses
        FROM transactions
        WHERE date >= @start AND date < @end
+         AND type != 'transfer'
        GROUP BY SUBSTR(date, 1, 7)`
     )
     .all({ start: previousYearStart.toISOString().slice(0, 10), end: currentYearStart.toISOString().slice(0, 10) }) as YearlySpendRow[]
@@ -435,6 +469,68 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
         previousYearMap.get(`${start.getFullYear() - 1}-${String(monthIndex + 1).padStart(2, "0")}`) ?? 0,
     })
   }
+
+  const accountRows = db
+    .prepare("SELECT id, name FROM accounts ORDER BY name COLLATE NOCASE")
+    .all() as AccountRow[]
+
+  const activityRows = db
+    .prepare(
+      `SELECT
+         account AS name,
+         SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) AS inflow,
+         SUM(CASE WHEN amount < 0 THEN ABS(amount) ELSE 0 END) AS outflow,
+         COUNT(id) AS transactions
+       FROM transactions
+       WHERE date >= @start AND date < @end
+         AND type != 'transfer'
+       GROUP BY account`
+    )
+    .all({ start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) }) as AccountActivityRow[]
+
+  const accountMap = new Map<string, { id: string; name: string; inflow: number; outflow: number; transactions: number }>()
+
+  accountRows.forEach((account) => {
+    const key = account.name.toLowerCase()
+    accountMap.set(key, { id: account.id, name: account.name, inflow: 0, outflow: 0, transactions: 0 })
+  })
+
+  activityRows.forEach((row) => {
+    const name = (row.name ?? "Unspecified").trim() || "Unspecified"
+    const key = name.toLowerCase()
+    const inflow = Number(row.inflow ?? 0)
+    const outflow = Number(row.outflow ?? 0)
+    const transactions = Number(row.transactions ?? 0)
+    const existing = accountMap.get(key)
+
+    if (existing) {
+      existing.inflow = inflow
+      existing.outflow = outflow
+      existing.transactions = transactions
+    } else {
+      accountMap.set(key, {
+        id: `account:${key}`,
+        name,
+        inflow,
+        outflow,
+        transactions,
+      })
+    }
+  })
+
+  const accounts: AccountSummary[] = Array.from(accountMap.values()).map((entry) => ({
+    ...entry,
+    net: entry.inflow - entry.outflow,
+  }))
+
+  accounts.sort((a, b) => {
+    const activityA = a.inflow + a.outflow
+    const activityB = b.inflow + b.outflow
+    if (activityA === activityB) {
+      return a.name.localeCompare(b.name)
+    }
+    return activityB - activityA
+  })
 
   const overBudget = categoryPerformances.filter((category) => category.budget > 0 && category.spent > category.budget)
 
@@ -481,5 +577,6 @@ export async function getReportAnalytics(period: ReportPeriodKey): Promise<Repor
     categoryTrend: { data: trendData, series: trendSeries },
     yearlyComparison,
     insights,
+    accounts,
   }
 }

--- a/lib/reports/pdf.ts
+++ b/lib/reports/pdf.ts
@@ -1,0 +1,729 @@
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib"
+
+import type { AccountSummary, ReportAnalytics, SummaryMetric } from "@/lib/reports/analytics"
+
+const PAGE_WIDTH = 612
+const PAGE_HEIGHT = 792
+const PAGE_MARGIN = 40
+const TEXT_COLOR = rgb(0.2, 0.24, 0.3)
+const MUTED_COLOR = rgb(0.45, 0.5, 0.58)
+const HEADER_COLOR = rgb(0.14, 0.2, 0.35)
+const POSITIVE_COLOR = rgb(0.13, 0.5, 0.35)
+const NEGATIVE_COLOR = rgb(0.7, 0.26, 0.26)
+const DIVIDER_COLOR = rgb(0.82, 0.86, 0.92)
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+const preciseCurrencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+})
+
+const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+
+function formatCurrency(value: number, precise = false) {
+  return precise ? preciseCurrencyFormatter.format(value) : currencyFormatter.format(value)
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null || Number.isNaN(value)) {
+    return "—"
+  }
+  const rounded = value.toFixed(1)
+  return `${value > 0 ? "+" : ""}${rounded}%`
+}
+
+function parseIsoDate(value: string): Date | null {
+  if (!value) return null
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function formatDateRange(start: string, end: string) {
+  const startDate = parseIsoDate(start)
+  const endDate = parseIsoDate(end)
+  if (!startDate || !endDate) {
+    return `${start} – ${end}`
+  }
+
+  const inclusiveEnd = new Date(endDate.getTime() - 86_400_000)
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+
+  return `${formatter.format(startDate)} – ${formatter.format(inclusiveEnd)}`
+}
+
+function normalizeHex(hex: string) {
+  const cleaned = hex.replace("#", "").trim()
+  return cleaned.length === 3
+    ? cleaned
+        .split("")
+        .map((char) => `${char}${char}`)
+        .join("")
+    : cleaned.padStart(6, "0")
+}
+
+function hexToRgb(hex: string) {
+  const normalized = normalizeHex(hex)
+  const value = Number.parseInt(normalized, 16)
+  const r = (value >> 16) & 255
+  const g = (value >> 8) & 255
+  const b = value & 255
+  return rgb(r / 255, g / 255, b / 255)
+}
+
+function wrapText(text: string, font: any, size: number, maxWidth: number) {
+  if (!text) return [""]
+  const words = text.split(/\s+/)
+  const lines: string[] = []
+  let current = ""
+
+  for (const word of words) {
+    const tentative = current ? `${current} ${word}` : word
+    const width = font.widthOfTextAtSize(tentative, size)
+    if (width <= maxWidth || !current) {
+      current = tentative
+      continue
+    }
+
+    lines.push(current)
+    current = word
+  }
+
+  if (current) {
+    lines.push(current)
+  }
+
+  return lines
+}
+export async function buildReportPdf(report: ReportAnalytics): Promise<Uint8Array> {
+  const doc = await PDFDocument.create()
+  const [regularFont, boldFont, italicFont] = await Promise.all([
+    doc.embedFont(StandardFonts.Helvetica),
+    doc.embedFont(StandardFonts.HelveticaBold),
+    doc.embedFont(StandardFonts.HelveticaOblique),
+  ])
+
+  const pageSize: [number, number] = [PAGE_WIDTH, PAGE_HEIGHT]
+  let page = doc.addPage(pageSize)
+  let cursorY = page.getHeight() - PAGE_MARGIN
+
+  const startNewPage = () => {
+    page = doc.addPage(pageSize)
+    cursorY = page.getHeight() - PAGE_MARGIN
+  }
+
+  const ensureSpace = (height: number) => {
+    if (cursorY - height < PAGE_MARGIN) {
+      startNewPage()
+    }
+  }
+
+  const drawSpacer = (space: number) => {
+    ensureSpace(space)
+    cursorY -= space
+  }
+
+  const drawTextLine = (
+    text: string,
+    {
+      size = 12,
+      font = regularFont,
+      color = TEXT_COLOR,
+      lineHeight = size + 6,
+      x = PAGE_MARGIN,
+    }: { size?: number; font?: any; color?: ReturnType<typeof rgb>; lineHeight?: number; x?: number } = {},
+  ) => {
+    ensureSpace(lineHeight)
+    const baseline = cursorY - size
+    page.drawText(text, {
+      x,
+      y: baseline,
+      size,
+      font,
+      color,
+    })
+    cursorY -= lineHeight
+  }
+
+  const drawDivider = () => {
+    ensureSpace(12)
+    const y = cursorY - 8
+    page.drawRectangle({
+      x: PAGE_MARGIN,
+      y,
+      width: page.getWidth() - PAGE_MARGIN * 2,
+      height: 1,
+      color: DIVIDER_COLOR,
+    })
+    cursorY -= 12
+  }
+
+  const drawSectionHeading = (title: string, subtitle?: string) => {
+    drawTextLine(title, { font: boldFont, size: 14, lineHeight: 22, color: HEADER_COLOR })
+    if (subtitle) {
+      drawTextLine(subtitle, { size: 11, lineHeight: 16, color: MUTED_COLOR })
+    }
+  }
+
+  const drawSummaryCards = (metrics: SummaryMetric[]) => {
+    if (metrics.length === 0) {
+      return
+    }
+
+    const columns = 2
+    const gap = 14
+    const cardWidth = (page.getWidth() - PAGE_MARGIN * 2 - gap * (columns - 1)) / columns
+    const cardHeight = 72
+
+    metrics.forEach((metric, index) => {
+      const column = index % columns
+      if (column === 0) {
+        ensureSpace(cardHeight + (index === 0 ? 0 : gap))
+        if (index !== 0) {
+          cursorY -= gap
+        }
+      }
+
+      const top = cursorY
+      const bottom = top - cardHeight
+      const x = PAGE_MARGIN + column * (cardWidth + gap)
+
+      page.drawRectangle({
+        x,
+        y: bottom,
+        width: cardWidth,
+        height: cardHeight,
+        color: rgb(0.95, 0.97, 1),
+        borderColor: rgb(0.82, 0.88, 0.97),
+        borderWidth: 1,
+      })
+
+      page.drawText(metric.label, {
+        x: x + 12,
+        y: top - 20,
+        size: 11,
+        font: boldFont,
+        color: HEADER_COLOR,
+      })
+
+      page.drawText(formatCurrency(metric.value, true), {
+        x: x + 12,
+        y: top - 38,
+        size: 16,
+        font: boldFont,
+        color: TEXT_COLOR,
+      })
+
+      if (metric.helper) {
+        page.drawText(metric.helper, {
+          x: x + 12,
+          y: top - 54,
+          size: 9,
+          font: italicFont,
+          color: MUTED_COLOR,
+        })
+      }
+
+      const changeText = metric.change === null ? "No comparison" : formatPercent(metric.change)
+      const changeColor = metric.change === null ? MUTED_COLOR : metric.change >= 0 ? POSITIVE_COLOR : NEGATIVE_COLOR
+      page.drawText(changeText, {
+        x: x + 12,
+        y: bottom + 14,
+        size: 10,
+        font: regularFont,
+        color: changeColor,
+      })
+
+      if (column === columns - 1 || index === metrics.length - 1) {
+        cursorY = bottom
+      }
+    })
+  }
+  const drawBulletList = (items: string[], options?: { bullet?: string }) => {
+    if (items.length === 0) {
+      drawTextLine("No highlights available yet.", { size: 11, color: MUTED_COLOR })
+      return
+    }
+
+    const bullet = options?.bullet ?? "•"
+    const fontSize = 11
+    const lineHeight = fontSize + 6
+    const bulletX = PAGE_MARGIN + 2
+    const textX = bulletX + 10
+    const maxWidth = page.getWidth() - textX - PAGE_MARGIN
+
+    items.forEach((item) => {
+      const lines = wrapText(item, regularFont, fontSize, maxWidth)
+      const rowHeight = lineHeight * lines.length
+      ensureSpace(rowHeight)
+      lines.forEach((line, lineIndex) => {
+        const baseline = cursorY - fontSize
+        if (lineIndex === 0) {
+          page.drawText(bullet, {
+            x: bulletX,
+            y: baseline,
+            size: fontSize,
+            font: boldFont,
+            color: HEADER_COLOR,
+          })
+        }
+        page.drawText(line, {
+          x: textX,
+          y: baseline,
+          size: fontSize,
+          font: regularFont,
+          color: TEXT_COLOR,
+        })
+        cursorY -= lineHeight
+      })
+    })
+  }
+
+  const drawCategoryTable = () => {
+    const categories = report.categories.slice(0, 6)
+    if (categories.length === 0) {
+      drawTextLine("Categorize more transactions to unlock category analytics.", { size: 11, color: MUTED_COLOR })
+      return
+    }
+
+    const columns = [
+      { width: 220 },
+      { width: 90 },
+      { width: 90 },
+      { width: 80 },
+      { width: 52 },
+    ]
+    const headers = ["Category", "Spent", "Budget", "Usage", "Txns"]
+    const rowHeight = 22
+
+    const tableWidth = columns.reduce((total, column) => total + column.width, 0)
+    const startX = PAGE_MARGIN
+
+    const drawHeaderRow = () => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.9, 0.93, 0.98) })
+
+      let columnX = startX
+      headers.forEach((header, index) => {
+        page.drawText(header, {
+          x: columnX + 6,
+          y: y + rowHeight - 14,
+          size: 10,
+          font: boldFont,
+          color: HEADER_COLOR,
+        })
+        columnX += columns[index].width
+      })
+    }
+
+    drawHeaderRow()
+
+    categories.forEach((category, index) => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      if (index % 2 === 0) {
+        page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.97, 0.98, 1) })
+      }
+
+      let columnX = startX
+      const colorHex = category.colorHex || "#64748b"
+      const swatchColor = hexToRgb(colorHex)
+
+      page.drawRectangle({ x: columnX + 6, y: y + 6, width: 8, height: 10, color: swatchColor })
+      page.drawText(category.name, {
+        x: columnX + 20,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: TEXT_COLOR,
+      })
+      columnX += columns[0].width
+
+      const spentText = formatCurrency(category.spent, true)
+      const spentX = columnX + columns[1].width - 6 - regularFont.widthOfTextAtSize(spentText, 10)
+      page.drawText(spentText, {
+        x: spentX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: TEXT_COLOR,
+      })
+      columnX += columns[1].width
+
+      const budgetText = category.budget > 0 ? formatCurrency(category.budget, true) : "—"
+      const budgetX = columnX + columns[2].width - 6 - regularFont.widthOfTextAtSize(budgetText, 10)
+      page.drawText(budgetText, {
+        x: budgetX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: MUTED_COLOR,
+      })
+      columnX += columns[2].width
+
+      const usagePercent = category.budget > 0 ? (category.spent / category.budget) * 100 : null
+      const usageText = usagePercent === null ? "—" : `${Math.round(usagePercent)}%`
+      const usageColor = usagePercent !== null && usagePercent > 100 ? NEGATIVE_COLOR : TEXT_COLOR
+      const usageX = columnX + columns[3].width - 6 - regularFont.widthOfTextAtSize(usageText, 10)
+      page.drawText(usageText, {
+        x: usageX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: usageColor,
+      })
+      columnX += columns[3].width
+
+      const txnText = integerFormatter.format(category.transactions)
+      const txnX = columnX + columns[4].width - 6 - regularFont.widthOfTextAtSize(txnText, 10)
+      page.drawText(txnText, {
+        x: txnX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: MUTED_COLOR,
+      })
+    })
+
+    if (report.categories.length > categories.length) {
+      drawTextLine(`+${report.categories.length - categories.length} more categories`, {
+        size: 10,
+        color: MUTED_COLOR,
+        lineHeight: 14,
+      })
+    }
+  }
+  const drawAccountTable = (accounts: AccountSummary[]) => {
+    if (accounts.length === 0) {
+      drawTextLine("Create accounts to track how money moves between them.", { size: 11, color: MUTED_COLOR })
+      return
+    }
+
+    const rows = accounts.slice(0, 8)
+    const columns = [
+      { width: 220 },
+      { width: 96 },
+      { width: 96 },
+      { width: 80 },
+      { width: 40 },
+    ]
+    const headers = ["Account", "Inflows", "Outflows", "Net", "Txns"]
+    const rowHeight = 22
+    const tableWidth = columns.reduce((total, column) => total + column.width, 0)
+    const startX = PAGE_MARGIN
+
+    const drawHeaderRow = () => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.9, 0.93, 0.98) })
+
+      let columnX = startX
+      headers.forEach((header, index) => {
+        page.drawText(header, {
+          x: columnX + 6,
+          y: y + rowHeight - 14,
+          size: 10,
+          font: boldFont,
+          color: HEADER_COLOR,
+        })
+        columnX += columns[index].width
+      })
+    }
+
+    drawHeaderRow()
+
+    rows.forEach((account, index) => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      if (index % 2 === 0) {
+        page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.97, 0.98, 1) })
+      }
+
+      let columnX = startX
+      page.drawText(account.name, {
+        x: columnX + 6,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: TEXT_COLOR,
+      })
+      columnX += columns[0].width
+
+      const inflowText = formatCurrency(account.inflow, true)
+      const inflowX = columnX + columns[1].width - 6 - regularFont.widthOfTextAtSize(inflowText, 10)
+      page.drawText(inflowText, {
+        x: inflowX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: POSITIVE_COLOR,
+      })
+      columnX += columns[1].width
+
+      const outflowText = formatCurrency(-account.outflow, true)
+      const outflowX = columnX + columns[2].width - 6 - regularFont.widthOfTextAtSize(outflowText, 10)
+      page.drawText(outflowText, {
+        x: outflowX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: NEGATIVE_COLOR,
+      })
+      columnX += columns[2].width
+
+      const netText = formatCurrency(account.net, true)
+      const netColor = account.net > 0 ? POSITIVE_COLOR : account.net < 0 ? NEGATIVE_COLOR : MUTED_COLOR
+      const netX = columnX + columns[3].width - 6 - regularFont.widthOfTextAtSize(netText, 10)
+      page.drawText(netText, {
+        x: netX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: netColor,
+      })
+      columnX += columns[3].width
+
+      const txnText = integerFormatter.format(account.transactions)
+      const txnX = columnX + columns[4].width - 6 - regularFont.widthOfTextAtSize(txnText, 10)
+      page.drawText(txnText, {
+        x: txnX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: MUTED_COLOR,
+      })
+    })
+
+    if (accounts.length > rows.length) {
+      drawTextLine(`+${accounts.length - rows.length} more accounts`, { size: 10, color: MUTED_COLOR, lineHeight: 14 })
+    }
+  }
+
+  const drawCashFlowTable = () => {
+    const months = report.incomeExpense.slice(-6)
+    if (months.length === 0) {
+      drawTextLine("Record income and expenses to see cash flow trends.", { size: 11, color: MUTED_COLOR })
+      return
+    }
+
+    const columns = [
+      { width: 120 },
+      { width: 120 },
+      { width: 120 },
+      { width: 120 },
+    ]
+    const headers = ["Month", "Income", "Expenses", "Net"]
+    const rowHeight = 22
+    const tableWidth = columns.reduce((total, column) => total + column.width, 0)
+    const startX = PAGE_MARGIN
+
+    const drawHeaderRow = () => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.9, 0.93, 0.98) })
+
+      let columnX = startX
+      headers.forEach((header, index) => {
+        page.drawText(header, {
+          x: columnX + 6,
+          y: y + rowHeight - 14,
+          size: 10,
+          font: boldFont,
+          color: HEADER_COLOR,
+        })
+        columnX += columns[index].width
+      })
+    }
+
+    drawHeaderRow()
+
+    months.forEach((month, index) => {
+      ensureSpace(rowHeight)
+      cursorY -= rowHeight
+      const y = cursorY
+      if (index % 2 === 0) {
+        page.drawRectangle({ x: startX, y, width: tableWidth, height: rowHeight, color: rgb(0.97, 0.98, 1) })
+      }
+
+      const net = month.income - month.expenses
+
+      let columnX = startX
+      page.drawText(month.month, {
+        x: columnX + 6,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: TEXT_COLOR,
+      })
+      columnX += columns[0].width
+
+      const incomeText = formatCurrency(month.income, true)
+      const incomeX = columnX + columns[1].width - 6 - regularFont.widthOfTextAtSize(incomeText, 10)
+      page.drawText(incomeText, {
+        x: incomeX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: POSITIVE_COLOR,
+      })
+      columnX += columns[1].width
+
+      const expenseText = formatCurrency(-month.expenses, true)
+      const expenseX = columnX + columns[2].width - 6 - regularFont.widthOfTextAtSize(expenseText, 10)
+      page.drawText(expenseText, {
+        x: expenseX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: NEGATIVE_COLOR,
+      })
+      columnX += columns[2].width
+
+      const netText = formatCurrency(net, true)
+      const netColor = net > 0 ? POSITIVE_COLOR : net < 0 ? NEGATIVE_COLOR : MUTED_COLOR
+      const netX = columnX + columns[3].width - 6 - regularFont.widthOfTextAtSize(netText, 10)
+      page.drawText(netText, {
+        x: netX,
+        y: y + 6,
+        size: 10,
+        font: regularFont,
+        color: netColor,
+      })
+    })
+  }
+  const drawHighlightsSection = () => {
+    drawSectionHeading("Highlights", "Key takeaways captured during this period.")
+    if (report.highlights.length === 0) {
+      drawTextLine("Highlights will appear once more activity is categorized.", { size: 11, color: MUTED_COLOR })
+    } else {
+      drawBulletList(report.highlights)
+    }
+
+    if (report.insights.length > 0) {
+      drawSpacer(8)
+      drawSectionHeading("Insights", "Automatic observations based on your data.")
+      const insightItems = report.insights.map((insight) => `${insight.title} — ${insight.description}`)
+      drawBulletList(insightItems)
+    }
+  }
+
+  const drawYearlySummary = () => {
+    if (report.yearlyComparison.length === 0) {
+      return
+    }
+
+    const totals = report.yearlyComparison.reduce(
+      (acc, row) => {
+        acc.current += row.current
+        acc.previous += row.previous
+        return acc
+      },
+      { current: 0, previous: 0 },
+    )
+
+    const change = totals.previous === 0 ? null : ((totals.current - totals.previous) / totals.previous) * 100
+    const changeText = change === null ? "No prior year data" : formatPercent(change)
+    const changeColor = change === null ? MUTED_COLOR : change >= 0 ? POSITIVE_COLOR : NEGATIVE_COLOR
+
+    drawTextLine(`Current year spending: ${formatCurrency(totals.current, true)}`, {
+      size: 11,
+      color: TEXT_COLOR,
+    })
+    drawTextLine(`Previous year spending: ${formatCurrency(totals.previous, true)}`, {
+      size: 11,
+      color: MUTED_COLOR,
+    })
+    drawTextLine(`Change: ${changeText}`, {
+      size: 11,
+      color: changeColor,
+    })
+
+    const highestCurrent = report.yearlyComparison.reduce((prev, row) => (row.current > prev.current ? row : prev))
+    const highestPrevious = report.yearlyComparison.reduce((prev, row) => (row.previous > prev.previous ? row : prev))
+
+    drawTextLine(
+      `Peak month this year: ${highestCurrent.month} (${formatCurrency(highestCurrent.current, true)})`,
+      { size: 10, color: TEXT_COLOR, lineHeight: 14 },
+    )
+    drawTextLine(
+      `Peak month last year: ${highestPrevious.month} (${formatCurrency(highestPrevious.previous, true)})`,
+      { size: 10, color: MUTED_COLOR, lineHeight: 14 },
+    )
+  }
+
+  const currentPeriodLabel = formatDateRange(report.startDate, report.endDate)
+  const generatedAt = new Date()
+
+  drawTextLine("CashTrack Financial Report", {
+    font: boldFont,
+    size: 22,
+    lineHeight: 30,
+    color: HEADER_COLOR,
+  })
+  drawTextLine(report.label, { font: boldFont, size: 14, lineHeight: 20 })
+  drawTextLine(currentPeriodLabel, { size: 11, color: MUTED_COLOR, lineHeight: 16 })
+  drawTextLine(`Generated on ${generatedAt.toLocaleString()}`, { size: 10, color: MUTED_COLOR, lineHeight: 16 })
+  drawDivider()
+
+  drawSectionHeading("Key metrics", "A snapshot of income, expenses, and savings performance.")
+  drawSummaryCards(report.summary)
+  drawSpacer(18)
+
+  drawHighlightsSection()
+  drawSpacer(18)
+
+  drawSectionHeading("Top spending categories", "Where your money went during this period.")
+  drawCategoryTable()
+  drawSpacer(18)
+
+  drawSectionHeading("Account activity", "Monitor how money moved between your accounts.")
+  drawAccountTable(report.accounts)
+  drawSpacer(18)
+
+  drawSectionHeading("Monthly cash flow", "Income versus expenses over the most recent months.")
+  drawCashFlowTable()
+  drawSpacer(18)
+
+  drawSectionHeading("Yearly comparison", "Compare this year's spending to the prior year.")
+  drawYearlySummary()
+
+  const footerPage = page
+  footerPage.drawRectangle({
+    x: PAGE_MARGIN,
+    y: PAGE_MARGIN / 2,
+    width: footerPage.getWidth() - PAGE_MARGIN * 2,
+    height: 0.5,
+    color: DIVIDER_COLOR,
+  })
+  footerPage.drawText("cashtrack", {
+    x: PAGE_MARGIN,
+    y: PAGE_MARGIN / 2 + 4,
+    size: 9,
+    font: boldFont,
+    color: HEADER_COLOR,
+  })
+  footerPage.drawText("Household insights at a glance", {
+    x: footerPage.getWidth() - PAGE_MARGIN - regularFont.widthOfTextAtSize("Household insights at a glance", 9),
+    y: PAGE_MARGIN / 2 + 4,
+    size: 9,
+    font: regularFont,
+    color: MUTED_COLOR,
+  })
+
+  return doc.save()
+}

--- a/lib/sync/schemas.ts
+++ b/lib/sync/schemas.ts
@@ -9,8 +9,10 @@ export const transactionSchema = z.object({
   amount: z.number(),
   account: z.string().min(1),
   status: z.enum(["pending", "completed", "cleared"]),
-  type: z.enum(["income", "expense"]),
+  type: z.enum(["income", "expense", "transfer"]),
   notes: z.string().nullable().optional(),
+  transferGroupId: z.string().min(1).optional().nullable(),
+  transferDirection: z.enum(["in", "out"]).optional().nullable(),
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1),
 })
@@ -21,6 +23,13 @@ export const categorySchema = z.object({
   icon: z.string().min(1),
   color: z.string().min(1),
   monthlyBudget: z.number().nonnegative(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+})
+
+export const accountSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
   createdAt: z.string().min(1),
   updatedAt: z.string().min(1),
 })
@@ -56,6 +65,7 @@ export const userSchema = z.object({
 export const syncPushPayloadSchema = z.object({
   transactions: z.array(transactionSchema).optional(),
   categories: z.array(categorySchema).optional(),
+  accounts: z.array(accountSchema).optional(),
   rules: z.array(automationRuleSchema).optional(),
   settings: z.array(settingRowSchema).optional(),
   users: z.array(userSchema).optional(),
@@ -66,6 +76,7 @@ export const backupSnapshotSchema = z.object({
   exportedAt: z.string().min(1),
   transactions: z.array(transactionSchema),
   categories: z.array(categorySchema),
+  accounts: z.array(accountSchema),
   rules: z.array(automationRuleSchema),
   settings: z.array(settingRowSchema),
   users: z.array(userSchema),

--- a/lib/transactions/types.ts
+++ b/lib/transactions/types.ts
@@ -1,4 +1,4 @@
-export type TransactionType = "income" | "expense"
+export type TransactionType = "income" | "expense" | "transfer"
 
 export type TransactionStatus = "pending" | "completed" | "cleared"
 
@@ -13,6 +13,8 @@ export interface Transaction {
   status: TransactionStatus
   type: TransactionType
   notes: string | null
+  transferGroupId: string | null
+  transferDirection: "in" | "out" | null
   createdAt: string
   updatedAt: string
 }
@@ -77,6 +79,16 @@ export interface ParsedCsvTransaction {
   account?: string
   status?: TransactionStatus
   type?: TransactionType
+  notes?: string | null
+}
+
+export interface CreateTransferInput {
+  date: string
+  description: string
+  amount: number
+  fromAccount: string
+  toAccount: string
+  status: TransactionStatus
   notes?: string | null
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "lucide-react": "^0.454.0",
         "next": "^14.2.32",
         "next-themes": "latest",
+        "pdf-lib": "^1.17.1",
+        "pdf-parse": "^1.1.1",
         "react": "^18",
         "react-day-picker": "9.8.0",
         "react-dom": "^18",
@@ -1006,6 +1008,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6853,7 +6873,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7002,6 +7021,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.21",
@@ -7243,6 +7268,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7292,6 +7323,46 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lucide-react": "^0.454.0",
     "next": "^14.2.32",
     "next-themes": "latest",
+    "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "react": "^18",
     "react-day-picker": "9.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.1
@@ -535,6 +538,12 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -2654,6 +2663,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2672,6 +2684,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pdf-parse@1.1.1:
     resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
@@ -3065,6 +3080,9 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3446,6 +3464,14 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@radix-ui/number@1.1.0': {}
 
@@ -4958,8 +4984,8 @@ snapshots:
       '@typescript-eslint/parser': 8.44.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -4978,7 +5004,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4989,22 +5015,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.44.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5015,7 +5041,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5760,6 +5786,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5771,6 +5799,13 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pdf-parse@1.1.1:
     dependencies:
@@ -6227,6 +6262,8 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary
- add API, data layer, and UI updates so transactions use managed accounts with creation from the form, inline management tools, and automatic onboarding of legacy accounts into the managed list
- expand analytics with account activity tables, brighter chart palettes tied to categories, and a PDF export endpoint with client download actions while excluding transfer noise
- wire up a dedicated transfer workflow that pairs transactions with shared metadata, updates sync schemas, and keeps reporting totals accurate

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d14c7bf10883279b4e351441692e2e