### PR TITLE
docs: refresh readme and installation guide

### DIFF
--- a/docs/LOCAL_INSTALLATION.md
+++ b/docs/LOCAL_INSTALLATION.md
@@ -1,120 +1,120 @@
 # Local installation guide
 
-This document walks through installing CashTrack on Windows, macOS, and Linux without relying on any hosted services. The application is designed to run entirely offline: all data is stored in a local SQLite database, session cookies are issued by iron-session, and a service worker keeps the UI responsive even when the network disappears.
+CashTrack is designed to run entirely on your own hardware. This guide covers the prerequisites, setup steps, and platform-specific tweaks needed to keep everything private and offline while still enabling household sharing over your local network.
 
-## Requirements
+## Before you start
 
-- Node.js 18 or later (LTS recommended)
-- npm 9+ (or the bundled version that ships with Node LTS)
-- Git (for cloning the repository)
-- Optional: Inno Setup 6+ for building the Windows installer
+| Requirement | Details |
+| --- | --- |
+| **Node.js** | Version 18.18 or newer (20 LTS recommended for best performance). |
+| **npm** | npm 9+ (bundled with recent Node releases). |
+| **Git** | Used to clone the repository. |
+| **Optional tooling** | [Inno Setup 6+](https://jrsoftware.org/isinfo.php) for the Windows installer, `openssl` (macOS/Linux) or PowerShell for generating secrets. |
 
-The following environment variables control where CashTrack stores data and how it identifies itself to other devices:
+> 💡 **Tip:** On Windows, run `npm install --include=optional` if you skipped optional dependencies; the Windows service helper relies on the `node-windows` package.
+
+## 1. Clone the repository and install dependencies
+
+```bash
+git clone https://github.com/sxwxbxr/CashTrack.git
+cd CashTrack
+npm install
+```
+
+The install step generates PWA icons (via the `postinstall` script) and installs the platform-specific tooling needed for packaging.
+
+## 2. Configure environment variables
+
+Copy the example file and edit the values to suit your setup.
+
+```bash
+cp .env.example .env.local
+```
+
+Required variables:
 
 | Variable | Purpose | Default |
 | --- | --- | --- |
-| `CASHTRACK_SESSION_SECRET` | Secret used to encrypt the iron-session cookie. Must be set to a long random string in production. | *(required)* |
-| `CASHTRACK_DATA_DIR` | Directory containing `cashtrack.db`, WAL files, and backups. | `./data` |
-| `SYNC_HOST` | Base URL shown in the Settings page for LAN discovery. | `http://<local-ip>:3000` |
+| `CASHTRACK_SESSION_SECRET` | Encrypts iron-session cookies; must be long and random before exposing the app to other people. | *(none &mdash; required)* |
+| `CASHTRACK_DATA_DIR` | Folder containing `cashtrack.db`, WAL files, and JSON backups. Relative paths resolve from the project root. | `./data` |
+| `SYNC_HOST` | Optional URL shown in the Settings discovery banner for LAN peers. | `http://<your-lan-ip>:3000` |
 
-> ℹ️ **Tip:** Point `CASHTRACK_DATA_DIR` at a folder that is already synced with Syncthing, iCloud Drive, or a NAS share to replicate the SQLite database across household computers. The seed JSON files that ship in `data/` are imported automatically the first time the migrations run.
+Generate a session secret quickly:
 
-## Common setup steps
+```bash
+echo "CASHTRACK_SESSION_SECRET=$(openssl rand -base64 32)" >> .env.local
+```
 
-1. **Clone and install**
+```powershell
+Add-Content .env.local ("CASHTRACK_SESSION_SECRET=" + [Convert]::ToBase64String([byte[]](1..32 | ForEach-Object { Get-Random -Maximum 256 })))
+```
 
-   ```bash
-   git clone https://github.com/sxwxbxr/CashTrack.git
-   cd CashTrack
-   npm install
-   ```
+You can add any other custom variables supported by Next.js in the same `.env.local` file.
 
-2. **Configure environment variables**
+## 3. Initialise the database
 
-   Copy `.env.example` to `.env.local` (or `.env`) and set the variables listed above. Keep the session secret private.
+```bash
+npm run db:migrate
+```
 
-3. **Initialise the database**
+This script creates the SQLite schema, imports JSON seed files in `data/` (if present), and provisions the default household login (`household` / `cashtrack`). The credentials are marked with `mustChangePassword = 1`, so the UI will force a password change on first sign-in.
 
-   ```bash
-   npm run db:migrate
-   ```
+## 4. Run CashTrack
 
-   The migration script creates every table, enables Write-Ahead Logging, imports any existing JSON data, and seeds the default `household / cashtrack` user with `mustChangePassword = 1`.
+### Development mode
 
-4. **Run the dev server**
+```bash
+npm run dev
+```
 
-   ```bash
-   npm run dev
-   ```
+Visit [http://localhost:3000](http://localhost:3000), sign in with the default credentials, and immediately change the password under **Settings → Household account**.
 
-   Visit `http://localhost:3000`, sign in with the default credentials, and immediately change the password from **Settings → Household Account**. The middleware enforces a password change before any other HTML route loads.
+### Production preview
 
-## Windows
+```bash
+npm run build
+npm run start
+```
 
-CashTrack includes scripts for packaging a desktop build and running it as a background service.
+This runs the optimised Next.js server on port 3000. Set `PORT` before running `npm run start` if you need a different port.
 
-1. **Build the production bundle**
+## 5. Keep CashTrack running in the background
 
-   ```bash
-   npm run build:desktop
-   ```
+- **Windows service:**
+  1. Build the production bundle: `npm run build:desktop`.
+  2. Install the background service (requires an elevated terminal): `npm run service:install`.
+  3. Logs are stored under `%PROGRAMDATA%\CashTrack\logs` and the SQLite database lives in `%PROGRAMDATA%\CashTrack\data`.
+  4. Remove the service with `npm run service:uninstall`.
+- **macOS/Linux:**
+  - Use your preferred process manager (systemd, launchd, pm2, etc.) to run `npm run start` from the project directory.
+  - Ensure the user running the service has read/write access to `CASHTRACK_DATA_DIR`.
+  - Open firewall port 3000 (or the port you configure) so other LAN devices can connect.
 
-   - `release/windows/app` contains the Next.js production output, server scripts, and a `.env.production` template.
-   - `release/windows/runtime` should contain a portable Node runtime. Copy the contents of a Node zip distribution here or set the `CASHTRACK_NODE_RUNTIME` environment variable before running the build script.
+## Windows desktop distribution
 
-2. **Install the Windows service**
+If you want to ship CashTrack as an installer for family members, follow these steps:
 
-   ```bash
-   npm run service:install
-   ```
+1. Run `npm run build:desktop` to prepare `release/windows/app` and `release/windows/runtime`.
+   - Copy a portable Node.js runtime into `release/windows/runtime` or set the `CASHTRACK_NODE_RUNTIME` environment variable before running the script.
+2. Open `installer/windows/CashTrackInstaller.iss` in Inno Setup and build the installer.
+   - The installer copies files into `%ProgramFiles%/CashTrack`, registers the background service, and creates Start Menu/Desktop shortcuts pointing at `http://localhost:3000`.
 
-   This registers a "CashTrack Local Server" service that runs `next start --hostname 127.0.0.1 --port 3000`. Logs are written to `%PROGRAMDATA%\CashTrack\logs` and the SQLite database lives in `%PROGRAMDATA%\CashTrack\data`. Stop and remove the service with `npm run service:uninstall`.
+## Data directory, backups, and sync
 
-3. **Build the installer (optional)**
-
-   Open `installer/windows/CashTrackInstaller.iss` in Inno Setup. The script copies the `release/windows` directory to `%ProgramFiles%/CashTrack`, installs the Windows service, and creates Start Menu/Desktop shortcuts pointing at `http://localhost:3000`.
-
-4. **Desktop shortcuts**
-
-   After installation, launch the shortcut to open CashTrack in your default browser. The service keeps running in the background so LAN devices can sync even when no browser is open.
-
-## macOS & Linux
-
-1. Follow the **Common setup steps**.
-2. For a persistent server, create a simple process manager entry (e.g. a systemd unit or launchd plist) that runs `npm run start` from the project directory. Remember to set `CASHTRACK_DATA_DIR` to a writable path.
-3. To expose the server to other devices on the LAN, ensure the firewall allows inbound connections to port 3000 (or the port you choose). Update `SYNC_HOST` so the Settings page shows the correct URL.
-4. Optional: create a `.desktop` entry (Linux) or Automator app (macOS) that opens `http://localhost:3000` for quick access.
-
-## Backups & restore
-
-- **Manual export** – visit Settings and click **Export backup** or run `curl http://localhost:3000/api/sync/export -o cashtrack-backup.json`.
-- **Manual import** – upload a previously exported JSON file in Settings or `curl -F file=@cashtrack-backup.json http://localhost:3000/api/sync/import`.
-- **Automated retention** – enable automatic backups in Settings to record the last backup timestamp and retention window in the `settings` table. You can schedule a platform-specific task (Task Scheduler, cron, launchd) that calls the export endpoint on an interval.
-
-## LAN sync tips
-
-1. Enable **Allow LAN sync requests** in Settings. This flag is stored in the `settings` table and can be toggled remotely through `PATCH /api/settings` if you authenticate first.
-2. Use the displayed discovery URL (`SYNC_HOST`) when configuring other devices. Both `/api/sync/pull` and `/api/sync/push` expect a valid session cookie from the household account.
-3. For tools like Syncthing, keep `CASHTRACK_DATA_DIR` inside a synced folder and let Syncthing move the SQLite database around. WAL mode keeps file locking predictable across platforms.
-4. Track the `sync.lastSuccessfulAt` setting to confirm that at least one device has pushed or pulled recently.
-
-## Enabling HTTPS with a self-signed certificate
-
-CashTrack runs happily over HTTP on a trusted LAN, but you can layer HTTPS in front of it:
-
-1. Generate a certificate with [`mkcert`](https://github.com/FiloSottile/mkcert) or your preferred tooling.
-2. Trust the generated root certificate on every device that will access CashTrack:
-   - **Windows:** double-click the root certificate and import it into the "Trusted Root Certification Authorities" store.
-   - **macOS:** open Keychain Access, add the certificate to the System keychain, and set it to "Always Trust".
-   - **Linux:** place the certificate in `/usr/local/share/ca-certificates/` and run `sudo update-ca-certificates`.
-3. Proxy `npm run start` through a TLS terminator (Caddy, nginx, IIS, or Node's `https` module) that references the certificate files.
-4. Update `SYNC_HOST` to use `https://` so the Settings page advertises the secure URL. If you expose the service outside your LAN, rotate credentials regularly and consider restricting access with a firewall or VPN.
+- By default `CASHTRACK_DATA_DIR` resolves to `<project-root>/data`. Point it at a NAS, Syncthing, or cloud-synced folder if you prefer file-level replication.
+- Enable **Allow LAN sync requests** in Settings when you want to use the `/api/sync/{pull,push,export,import}` endpoints from another device. A valid session cookie is required for every call.
+- Export a snapshot from the UI or via `curl http://localhost:3000/api/sync/export -o cashtrack-backup.json`.
+- Restore data by uploading through Settings or with `curl -F file=@cashtrack-backup.json http://localhost:3000/api/sync/import`.
+- Automated backup retention settings live inside the `settings` table; schedule periodic exports using Task Scheduler, cron, or launchd if you want off-site copies.
 
 ## Troubleshooting
 
-- **Session errors:** ensure `CASHTRACK_SESSION_SECRET` is set and at least 16 characters long; otherwise iron-session will throw at startup.
-- **Database locked:** SQLite places `.db-wal` files next to the main database. If you see lock errors, verify that only one instance of the server is writing to the database or switch to LAN sync rather than syncing the raw DB file.
-- **Service worker cache:** during development you may need to hard refresh (Shift + Reload) to invalidate the cache after code changes.
-- **Linting and type checks:** run `npm run lint` before packaging to confirm TypeScript strict mode passes.
+| Issue | Fix |
+| --- | --- |
+| **"Session secret is required"** | Double-check that `CASHTRACK_SESSION_SECRET` is set and at least 16 characters long before running the server. |
+| **"SQLITE_BUSY" / database locked** | Verify that only one CashTrack server is writing to the SQLite database. When in doubt, rely on LAN sync instead of syncing the raw `.db` file. |
+| **Service worker caching stale assets** | Hard refresh (Shift + Reload) during development to bust the cache, or clear application storage in your browser dev tools. |
+| **Missing icons after clone** | Run `npm run postinstall` (or `npm install`) to regenerate the PWA icons in `public/icons`. |
+| **TypeScript or lint errors** | Run `npm run lint` and fix the reported issues before packaging a build. |
 
-Enjoy maintaining your household finances without depending on any cloud services!
+Enjoy maintaining your household finances without depending on any hosted service.

--- a/docs/media/dashboard-preview-placeholder.svg
+++ b/docs/media/dashboard-preview-placeholder.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="760" viewBox="0 0 1440 760">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5B8DEF" />
+      <stop offset="100%" stop-color="#1E1E2F" />
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#101323" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#1F2545" stop-opacity="0.95" />
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feOffset dx="0" dy="18" result="offset" />
+      <feGaussianBlur in="offset" stdDeviation="24" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.09  0 0 0 0 0.12  0 0 0 0 0.21  0 0 0 0.35 0" />
+    </filter>
+  </defs>
+  <rect width="1440" height="760" fill="url(#gradient)" rx="48" />
+  <g transform="translate(120 110)">
+    <rect width="1200" height="540" rx="36" fill="url(#card)" filter="url(#softShadow)" stroke="rgba(255,255,255,0.08)" stroke-width="2" />
+    <g transform="translate(80 72)">
+      <rect width="480" height="120" rx="24" fill="rgba(255,255,255,0.06)" />
+      <text x="40" y="56" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#FFFFFF" font-weight="600">Household cash flow</text>
+      <text x="40" y="96" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" fill="rgba(255,255,255,0.68)">12 month rolling outlook</text>
+      <g transform="translate(320 12)">
+        <path d="M0,76 C40,32 64,24 96,52 C128,80 160,60 192,28" fill="none" stroke="#8FE3CF" stroke-width="6" stroke-linecap="round" />
+        <circle cx="0" cy="76" r="6" fill="#8FE3CF" />
+        <circle cx="96" cy="52" r="6" fill="#8FE3CF" />
+        <circle cx="192" cy="28" r="6" fill="#8FE3CF" />
+      </g>
+    </g>
+    <g transform="translate(80 232)">
+      <rect width="400" height="216" rx="24" fill="rgba(255,255,255,0.04)" />
+      <text x="32" y="56" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" fill="#FFFFFF" font-weight="600">Budget utilisation</text>
+      <text x="32" y="96" font-family="'Inter', 'Segoe UI', sans-serif" font-size="18" fill="rgba(255,255,255,0.6)">Category breakdown</text>
+      <g transform="translate(60 120)">
+        <circle cx="68" cy="68" r="68" fill="rgba(255,255,255,0.05)" stroke="#8FE3CF" stroke-width="10" stroke-dasharray="320" stroke-dashoffset="80" />
+        <circle cx="68" cy="68" r="48" fill="none" stroke="#F8B26A" stroke-width="10" stroke-dasharray="220" stroke-dashoffset="120" />
+        <circle cx="68" cy="68" r="28" fill="none" stroke="#F27E7E" stroke-width="10" stroke-dasharray="160" stroke-dashoffset="60" />
+      </g>
+    </g>
+    <g transform="translate(520 232)">
+      <rect width="600" height="216" rx="24" fill="rgba(255,255,255,0.04)" />
+      <text x="32" y="56" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" fill="#FFFFFF" font-weight="600">Upcoming obligations</text>
+      <text x="32" y="96" font-family="'Inter', 'Segoe UI', sans-serif" font-size="18" fill="rgba(255,255,255,0.6)">Rules and reminders, ready to automate</text>
+      <g transform="translate(40 120)">
+        <rect x="0" y="0" width="520" height="32" rx="16" fill="rgba(255,255,255,0.08)" />
+        <rect x="0" y="48" width="440" height="32" rx="16" fill="rgba(143,227,207,0.55)" />
+        <rect x="0" y="96" width="360" height="32" rx="16" fill="rgba(248,178,106,0.55)" />
+        <rect x="0" y="144" width="460" height="32" rx="16" fill="rgba(242,126,126,0.55)" />
+      </g>
+    </g>
+    <text x="600" y="492" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" fill="rgba(255,255,255,0.55)" text-anchor="middle">
+      Replace with a real dashboard screenshot when you capture one.
+    </text>
+  </g>
+</svg>

--- a/docs/media/rules-automation-placeholder.svg
+++ b/docs/media/rules-automation-placeholder.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="760" viewBox="0 0 1440 760">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#181C2F" />
+      <stop offset="100%" stop-color="#2F3A5D" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="140%" height="140%">
+      <feOffset dx="0" dy="12" result="off" />
+      <feGaussianBlur in="off" stdDeviation="20" result="blur" />
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.1 0 0 0 0 0.2 0 0 0 0.3 0" />
+    </filter>
+  </defs>
+  <rect width="1440" height="760" fill="url(#bg)" rx="48" />
+  <g transform="translate(160 120)">
+    <rect width="1120" height="520" rx="36" fill="rgba(10,12,24,0.65)" stroke="rgba(255,255,255,0.08)" stroke-width="2" filter="url(#shadow)" />
+    <g transform="translate(120 88)">
+      <text x="0" y="0" font-family="'Inter', 'Segoe UI', sans-serif" font-size="48" font-weight="700" fill="#FFFFFF">Automation rules</text>
+      <text x="0" y="44" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" fill="rgba(255,255,255,0.65)">Outline the repetitive finance admin you never want to do twice.</text>
+    </g>
+    <g transform="translate(120 160)">
+      <rect width="880" height="92" rx="22" fill="rgba(255,255,255,0.04)" />
+      <circle cx="56" cy="46" r="28" fill="#8FE3CF" opacity="0.9" />
+      <text x="120" y="40" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" fill="#FFFFFF" font-weight="600">Rule designer</text>
+      <text x="120" y="70" font-family="'Inter', 'Segoe UI', sans-serif" font-size="18" fill="rgba(255,255,255,0.65)">Match CSV imports, vendor names, and amount ranges in one place.</text>
+    </g>
+    <g transform="translate(120 276)">
+      <rect width="880" height="92" rx="22" fill="rgba(255,255,255,0.04)" />
+      <circle cx="56" cy="46" r="28" fill="#F8B26A" opacity="0.9" />
+      <text x="120" y="40" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" fill="#FFFFFF" font-weight="600">One-click reapply</text>
+      <text x="120" y="70" font-family="'Inter', 'Segoe UI', sans-serif" font-size="18" fill="rgba(255,255,255,0.65)">Run your saved rules on fresh statements in seconds.</text>
+    </g>
+    <g transform="translate(120 392)">
+      <rect width="880" height="92" rx="22" fill="rgba(255,255,255,0.04)" />
+      <circle cx="56" cy="46" r="28" fill="#F27E7E" opacity="0.9" />
+      <text x="120" y="40" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" fill="#FFFFFF" font-weight="600">Audit-ready history</text>
+      <text x="120" y="70" font-family="'Inter', 'Segoe UI', sans-serif" font-size="18" fill="rgba(255,255,255,0.65)">Review previous syncs, overrides, and manual edits with full context.</text>
+    </g>
+    <text x="560" y="500" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" fill="rgba(255,255,255,0.52)" text-anchor="middle">Swap this placeholder out with real automation screenshots.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- redesign the root README with badges, feature highlights, quick-start steps, and architecture visuals
- add placeholder artwork for screenshots to make the documentation more visual
- overhaul the local installation guide with up-to-date setup steps, environment variable helpers, and platform-specific notes

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d257a86a4c83279ddde9a52b232035